### PR TITLE
Switch to public posit package manager

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "RSPM",
-        "URL": "https://rspm.cynkra.com/prod-cran/2023-07-03"
+        "URL": "https://packagemanager.posit.co/cran/2023-07-03"
       }
     ]
   },


### PR DESCRIPTION
This should make `renv::restore()` to work installing all the dependencies (MRAN was switched off recently so there might be still some steps to be undertaken on the internal one to support the transition).

If this is not working, or don't have time going through installing all the depenencies, run `renv::deactivate()` before rendering the qmd file. Still, you might have some missing pkgs needed to render the report that should be installed manually.

@findanna please let me know which solution works for you. Thanks!