### PR TITLE
Prune relevent variables even more

### DIFF
--- a/R/const.R
+++ b/R/const.R
@@ -10,13 +10,8 @@ dxgap_constants <- tibble::lst(
               "pop_density",
               "gdp",
               "c_newinc",
-              "new_labconf",
-              "c_cdr",
-              "c_newinc_100k",
-              "e_inc_100k",
               "e_inc_num",
               "e_mort_100k",
-              "e_pop_num",
               "culture",
               "smear",
               "xpert")


### PR DESCRIPTION
cc @findanna, @diabatem-find 

After keeping those that have a completion rate of 0.75, we can prune even more.

Reasons:

- `new_labconf`: highly correlated with `smear`, `culture` and`xpert`
- `c_cdr` is perfectly anti-correlated to `who_dxgap` computed by us
- `c_newinc_100k` is `c_newinc` per 100k
- `e_pop_num` is perfectly correlated with `pop_total`