### PR TITLE
Update imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,50 +17,29 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports: 
-    broom,
-    constructive,
-    corrr,
-    countrycode,
-    DiagrammeRsvg,
-    dials,
+    corrr
+    countrycode
     dm,
     dplyr,
-    forcats,
     fs,
     ggplot2,
-    glmnet,
-    gt,
     here,
-    htmltools,
     httr2,
-    knitr,
     lubridate,
-    parsnip,
-    performance,
-    pkgload,
     purrr,
     readr,
     readxl,
     recipes,
-    renv,
     rlang,
     rmarkdown,
-    rsample,
     rstudioapi,
     scales,
-    shiny,
     stringr,
     testthat,
     tibble,
     tidyr,
     tidyselect,
-    tidyverse,
-    tune,
-    usethis,
-    vctrs,
-    vdiffr,
-    workflowsets,
-    yardstick
+    vctrs
 Suggests: 
     testthat (>= 3.0.0),
     vdiffr


### PR DESCRIPTION
Fixes #125.

From what I understand there is no way to sync the `DESCRIPTION` file with `renv.lock`. This is because:

- `renv.lock` aims to specify exact package versions
- `DESCRIPTION` aims to specify minimum package versions

Consequently, if the aim for this project is to productionise this R package, I am not sure renv is a good long-term fit.

In any case, to update the `DESCRIPTION` file to match the project dependencies in the interim I ran the following to generate a list of packages which I then manually appended to `DESCRIPTION`:

```r
renv::dependencies(path = "R/") |> 
    dplyr::distinct(Package) |>
    dplyr::arrange(Package)
```