### PR TITLE
Expand extract_name

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -108,5 +108,5 @@ fetch_object <- function(obj_name, env) {
 }
 
 extract_name <- function(file_name) {
-  stringr::str_remove_all(file_name, "\\d{4}-\\d{2}-\\d{2}\\_|\\.csv$") # TODO ext should not be hardcoded
+  stringr::str_remove_all(file_name, "\\d{4}-\\d{2}-\\d{2}\\_|\\.[a-zA-Z0-9]+$")
 }

--- a/tests/testthat/test-import.R
+++ b/tests/testthat/test-import.R
@@ -1,0 +1,4 @@
+test_that("extract_name strips any file extension", {
+  expect_equal(extract_name("who_2023-07-28_estimates.csv"), "who_estimates")
+  expect_equal(extract_name("who_2023-07-28_estimates.xlsx"), "who_estimates")
+})


### PR DESCRIPTION
Closes #186 

- I've expanded the regex to catch any file extension ending. An altnerative, more restrictive method could be to just list the extensions to be excluded using the pipe syntax (e.g., `\.csv$|\\.xlsx$`). The former was chosen as it is more inclusive.
- I've also added a test that can be expanded to check any new file types.