### PR TITLE
Rename fun to avoid clash with base

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -1,4 +1,4 @@
-#' @example \dontrun{get_core(load())}
+#' @example \dontrun{get_core(load_dx())}
 get_core <- function(data_list) {
   country_notification_df <-
     data_list$who_notifications |>

--- a/R/load.R
+++ b/R/load.R
@@ -1,4 +1,4 @@
-load <- function(data_dir = Sys.getenv("DXGAP_DATADIR")) {
+load_dx <- function(data_dir = Sys.getenv("DXGAP_DATADIR")) {
 
   data_files <-
     list.files(here::here("inst/extdata"), pattern = "csv") |>

--- a/R/report.R
+++ b/R/report.R
@@ -20,7 +20,7 @@ render_report <- function(.template_name,
                           data_dir = Sys.getenv("DXGAP_DATADIR")) {
   template_path <- compose_file_path(.template_name, template_dir)
 
-  lst_df <- load()
+  lst_df <- load_dx()
   dm <- build_dm(lst_df, year = .year)
   data_tbl <- build_tbl(dm, vars = .vars)
 

--- a/inst/scripts/tbl_scr.R
+++ b/inst/scripts/tbl_scr.R
@@ -1,6 +1,6 @@
 library(tidyverse)
 pkgload::load_all()
-df_lst <- load()
+df_lst <- load_dx()
 
 dm <- build_dm(df_lst, year = 2019)
 data_tbl <- build_tbl(dm)

--- a/inst/template/explain_lm.Rmd
+++ b/inst/template/explain_lm.Rmd
@@ -34,7 +34,7 @@ data_tbl <- params$data_tbl
 The chosen year is `r params$year`.
 
 ```{r eval=FALSE}
-df_lst <- load()
+df_lst <- load_dx()
 dm <- build_dm(df_lst, year = 2019)
 data_tbl <- build_tbl(dm, vars = dxgap_constants$tb_vars)
 ```

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -1,5 +1,5 @@
 skip_if(Sys.getenv("DXGAP_DATADIR") == "")
-data_list <- load()
+data_list <- load_dx()
 test_that("get_cc_var_always_given_acrs_yrs() works", {
   who_notifications <- data_list$who_notifications
   core_df <-

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -1,5 +1,5 @@
 skip_if(Sys.getenv("DXGAP_DATADIR") == "")
-data_list <- load()
+data_list <- load_dx()
 test_that("build_dm()", {
   dm <- build_dm(data_list, year = 2019)
   expect_snapshot(dm::glimpse(dm))

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -1,5 +1,5 @@
-test_that("load() works", {
-  lst_df <- load()
+test_that("load_dx() works", {
+  lst_df <- load_dx()
   expect_type(lst_df, "list")
   expect_equal(length(lst_df), 12)
   expect_true(all(purrr::map_int(lst_df, nrow) > 0))


### PR DESCRIPTION
Closes #198 

I opted for `load_dx()` as a name. `load_data()` and `load_all()` are already exported by `devtools` so `load_dx` seems like a logic fit for this repo.