### PR TITLE
One step towards better `load_dx()`

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -1,10 +1,11 @@
-load_dx <- function(data_dir = Sys.getenv("DXGAP_DATADIR")) {
-
-  data_files <-
-    list.files(here::here("inst/extdata"), pattern = "csv") |>
+list_dx <- function(pattern = "csv", data_dir = Sys.getenv("DXGAP_DATADIR")) {
+  list.files(data_dir, pattern = pattern) |>
     stringr::str_subset("masterlist", negate = TRUE)
+}
 
-  lst_df <- import_bulk(lst_df, data_files)
+load_dx <- function(data_files = list_dx()) {
+
+  lst_df <- import_bulk(lst_df, data_name = data_files)
 
   # HBC countries --------------------------------------------------------------
 


### PR DESCRIPTION
It's still not optimal, but this is better. 
Listing files is extremely dangerous. If I have, for instance,  who_YYYY-MM_DD_outcomes.csv stored in my data dir that is not part of my supported list of data, the function would fail because it won't find a suitable `read_raw` function.

We still keep #199 open.

cc @MikeJohnPage.