### PR TITLE
Rm obsolete recipes

### DIFF
--- a/R/preproc_tb.R
+++ b/R/preproc_tb.R
@@ -85,33 +85,3 @@ get_core_recipe_tb <- function(recipe) {
     recipes::step_impute_median(recipes::has_role("impute_w_median")) |>
     recipes::step_rm(recipes::has_role("collinear"))
 }
-
-get_set_role_recipe_tb <- function(recipe) {
-  recipe |>
-    recipes::update_role(who_dx_gap, new_role = "outcome") |>
-    recipes::update_role(country_code, new_role = "id") |>
-    recipes::update_role(
-      tidyselect::any_of(
-        c(
-          "c_cdr", "c_newinc_100k", "notified_ref_community", "notified_ref",
-          "e_mort_100k", "e_pop_num", "new_labconf"
-        )
-      ),
-      new_role = "collinear"
-    ) |>
-    recipes::update_role(
-      tidyselect::any_of(c("pop_urban_perc", "pop_density")),
-      new_role = "no_norm"
-    ) |>
-    recipes::update_role(
-      tidyselect::any_of(
-        c(
-          "e_inc_100k", "e_inc_num", "c_newinc", "pop_total",
-          "pop_density", "pop_urban_perc", "gdp"
-        )
-      ),
-      new_role = "impute_w_median"
-    )
-}
-
-


### PR DESCRIPTION
As noticed by @MikeJohnPage in https://github.com/finddx/find.dxgap/pull/204#issuecomment-1764819591. 

Better remove them to avoid confusion and retrieve them using version control in case those are needed.