### PR TITLE
Setting `renv.config.mran.enabled` to FALSE

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,2 @@
+options(renv.config.mran.enabled = FALSE)
 source("renv/activate.R")


### PR DESCRIPTION
renv was still using MRAN, as reported by @findanna in #214, which was ditched off recently.

From https://github.com/rstudio/renv/issues/1343#issuecomment-1567615384, setting this option in the .Rprofile should prevent renv from falling back to MRAN. As far as I could read [here](https://rstudio.github.io/renv/news/index.html#renv-100), the new version of renv uses FALSE by default, but we are still running an older version. 

We should update to the latest version.
