### PR TITLE
Pass required args in read that make use of `dxgap_read_csv()`

### DIFF
--- a/R/hbc.R
+++ b/R/hbc.R
@@ -10,9 +10,9 @@ download_hbc <- function(file_name = tempfile("who_hbc_list", fileext = ".pdf"),
   invisible(normalizePath(file_path))
 }
 
-read_hbc <- function(...) {
+read_hbc <- function(file_name, data_dir = Sys.getenv("DXGAP_DATADIR")) {
   # TODO: extract table from pdf pdftools::pdf_text(file_path)[[8]]
-  dxgap_read_csv(...) |>
+  dxgap_read_csv(file_name = file_name, data_dir = data_dir) |>
     tibble::as_tibble()
 }
 

--- a/R/mlist.R
+++ b/R/mlist.R
@@ -1,5 +1,5 @@
-read_masterlist <- function(...) {
-  dxgap_read_csv(...)
+read_masterlist <- function(file_name, data_dir = Sys.getenv("DXGAP_DATADIR")) {
+  dxgap_read_csv(file_name = file_name, data_dir = data_dir)
 }
 
 tidy_masterlist <- function(data) {

--- a/R/wb.R
+++ b/R/wb.R
@@ -48,8 +48,8 @@ unnest_wb_resp <- function(data) {
     tidyr::unnest_wider(indicator, names_sep = "_")
 }
 
-read_wb <- function(...) {
-  dxgap_read_csv(...) |>
+read_wb <- function(file_name, data_dir = Sys.getenv("DXGAP_DATADIR")) {
+  dxgap_read_csv(file_name = file_name, data_dir = data_dir) |>
     tibble::as_tibble()
 }
 


### PR DESCRIPTION
Otherwise, as noted by @MikeJohnPage, the user is required to know what to pass into the dots.