### PR TITLE
Set `renv.config.autoloader.enabled = FALSE`

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,2 +1,2 @@
-options(renv.config.mran.enabled = FALSE)
+options(renv.config.mran.enabled = FALSE, renv.config.autoloader.enabled = FALSE)
 source("renv/activate.R")


### PR DESCRIPTION
Closes #239.

So that renv won't start by default. Call `renv::activate()` to make use of it.