### PR TITLE
Set min pkg version for core packages

### DIFF
--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -195,7 +195,7 @@
 
     Code
       dm::dm_examine_constraints(dm)
-    Message <cliMessage>
+    Message
       ! Unsatisfied constraints:
     Output
       * Table `country`: foreign key `year`, `country_code` into table `who_community`: values of `country$year`, `country$country_code` not in `who_community$year`, `who_community$country_code`: 2019, ALB (1), 2019, AND (1), 2019, ARE (1), 2019, ARG (1), 2019, ARM (1), ...
@@ -407,7 +407,7 @@
 
     Code
       dm::dm_examine_constraints(dm)
-    Message <cliMessage>
+    Message
       ! Unsatisfied constraints:
     Output
       * Table `country`: foreign key `year`, `country_code` into table `who_budget`: values of `country$year`, `country$country_code` not in `who_budget$year`, `who_budget$country_code`: 2016, AFG (1), 2016, AGO (1), 2016, ALB (1), 2016, AND (1), 2016, ARE (1), ...

--- a/tests/testthat/_snaps/tb_preproc.md
+++ b/tests/testthat/_snaps/tb_preproc.md
@@ -2,7 +2,7 @@
 
     Code
       recipe_tb
-    Message <cliMessage>
+    Message
       
       -- Recipe ----------------------------------------------------------------------
       


### PR DESCRIPTION
Closes #234.

Tests are passing with this set of package versions.

`<cliMessage>` is bothering in test-dm and test-preproc and have been stabilised with this pkg version.

```
  [1] colorspace_2.1-0    ellipsis_0.3.2      class_7.3-21        rprojroot_2.0.3     fs_1.6.2           
  [6] rstudioapi_0.15.0   furrr_0.3.1         listenv_0.9.0       dials_1.2.0         remotes_2.4.2.1    
 [11] prodlim_2023.08.28  fansi_1.0.4         lubridate_1.9.3     xml2_1.3.5          codetools_0.2-19   
 [16] splines_4.2.3       cachem_1.0.8        knitr_1.43          pkgload_1.3.2.1     workflows_1.1.3    
 [21] gt_0.10.0           broom_1.0.5         dbplyr_2.3.3        yardstick_1.2.0     tune_1.1.1         
 [26] shiny_1.7.4         readr_2.1.4         compiler_4.2.3      backports_1.4.1     Matrix_1.5-3       
 [31] fastmap_1.1.1       cli_3.6.1           later_1.3.1         htmltools_0.5.4     prettyunits_1.1.1  
 [36] tools_4.2.3         igraph_1.5.1        gtable_0.3.3        glue_1.6.2          dplyr_1.1.3        
 [41] corrr_0.4.4         rappdirs_0.3.3      Rcpp_1.0.10         DiceDesign_1.9      cellranger_1.1.0   
 [46] vctrs_0.6.3         countrycode_1.5.0   iterators_1.0.14    parsnip_1.1.0       insight_0.19.6     
 [51] timeDate_4022.108   xfun_0.39           gower_1.0.1         stringr_1.5.0       globals_0.16.2     
 [56] ps_1.7.5            brio_1.1.3          timechange_0.2.0    mime_0.12           miniUI_0.1.1.1     
 [61] lifecycle_1.0.3     devtools_2.4.5      future_1.33.0       MASS_7.3-60         scales_1.2.1       
 [66] ipred_0.9-14        hms_1.1.2           promises_1.2.1      parallel_4.2.3      httr2_1.0.0        
 [71] memoise_2.0.1       ggplot2_3.4.2       rpart_4.1.19        stringi_1.7.12      desc_1.4.2         
 [76] foreach_1.5.2       lhs_1.1.6           hardhat_1.3.0       pkgbuild_1.4.2      lava_1.7.2.1       
 [81] rlang_1.1.2         pkgconfig_2.0.3     rsample_1.1.1       evaluate_0.21       dm_1.0.8           
 [86] lattice_0.20-45     purrr_1.0.1         recipes_1.0.8       htmlwidgets_1.6.2   processx_3.8.2     
 [91] tidyselect_1.2.0    here_1.0.1          parallelly_1.36.0   magrittr_2.0.3      R6_2.5.1           
 [96] generics_0.1.3      profvis_0.3.8       DBI_1.1.3           pillar_1.9.0        withr_2.5.0        
[101] survival_3.5-3      nnet_7.3-18         tibble_3.2.1        future.apply_1.11.0 performance_0.10.8 
[106] crayon_1.5.2        utf8_1.2.3          tzdb_0.4.0          rmarkdown_2.23      urlchecker_1.0.1   
[111] workflowsets_1.0.1  usethis_2.2.2       grid_4.2.3          readxl_1.4.3        data.table_1.14.8  
[116] callr_3.7.3         digest_0.6.33       xtable_1.8-4        tidyr_1.3.0         httpuv_1.6.11      
[121] GPfit_1.0-8         munsell_0.5.0       sessioninfo_1.2.2 
```