### PR TITLE
Skip download_who() on CI/CD

### DIFF
--- a/tests/testthat/test-who_budget.R
+++ b/tests/testthat/test-who_budget.R
@@ -1,4 +1,5 @@
 test_that("WHO budget data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=budget")

--- a/tests/testthat/test-who_community.R
+++ b/tests/testthat/test-who_community.R
@@ -1,4 +1,5 @@
 test_that("WHO community data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=community")

--- a/tests/testthat/test-who_estimates.R
+++ b/tests/testthat/test-who_estimates.R
@@ -1,4 +1,5 @@
 test_that("WHO estimates data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=estimates")

--- a/tests/testthat/test-who_expenditure.R
+++ b/tests/testthat/test-who_expenditure.R
@@ -1,4 +1,5 @@
 test_that("WHO expenditures data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=expenditure_utilisation")

--- a/tests/testthat/test-who_labs.R
+++ b/tests/testthat/test-who_labs.R
@@ -1,4 +1,5 @@
 test_that("WHO labs data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=labs")

--- a/tests/testthat/test-who_notifications.R
+++ b/tests/testthat/test-who_notifications.R
@@ -1,4 +1,5 @@
 test_that("WHO notifications data is downloaded correctly", {
+  skip_on_ci()
   skip_if_not_installed("curl")
   skip_if_offline()
   skip_if_not_available("https://extranet.who.int/tme/generateCSV.asp?ds=notifications")


### PR DESCRIPTION
These are taking quite a lot, even when running tests locally. We skip those on CI/CD.
Closes #285.