### PR TITLE
Support custom year vector in `build_tbl()`

### DIFF
--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -85,7 +85,7 @@ build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) 
     return(dm_ts)
   }
 
-  dm::dm_filter(dm_ts, country = (year == !!year))
+  dm::dm_filter(dm_ts, country = (year %in% !!year))
 
 }
 

--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -29,12 +29,10 @@
 #' )
 #' }
 build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) {
-  # TODO: max year should be taken from dxgap_diseases
-  max_year <- 2021
-  if (!is.null(year) && max(year) > max_year) {
-    rlang::abort(sprintf("Data available up to %s.", max_year))
-  }
   disease <- attr(data_list, "disease")
+  check_supported_year(year = year, disease = disease)
+  # # TODO: max year should be taken from dxgap_diseases
+  max_year <- 2021
   if (is.null(estimated)) {
     estimated <- extract_default_dxgap_tbl_field(
       disease = disease,

--- a/R/build_tbl.R
+++ b/R/build_tbl.R
@@ -30,7 +30,14 @@
 #' \dontrun{
 #' build_tbl(
 #'   "tb",
-#'   2019,
+#'   year = 2019,
+#'   estimated = "who_estimates.e_inc_num",
+#'   notified = "who_notifications.c_newinc",
+#'   c("year", "country_code", "pop_density", "e_inc_num", "c_newinc")
+#' )
+#' build_tbl(
+#'   "tb",
+#'   year = 2019:2018,
 #'   estimated = "who_estimates.e_inc_num",
 #'   notified = "who_notifications.c_newinc",
 #'   c("year", "country_code", "pop_density", "e_inc_num", "c_newinc")

--- a/R/build_tbl.R
+++ b/R/build_tbl.R
@@ -17,8 +17,8 @@
 #'   for DX Gap computation. If kept to `NULL`, the function will use the value
 #'   `notifications_table.notifications_field` from the `notified` column in the
 #'   `dxgap_diseases` meta table.
-#' @param year An integer indicating a year to filter the data on. Defaults to
-#'   NULL, returning all years present in the data.
+#' @param year An integer vector indicating consecutive years to filter the
+#'   data on. Defaults to NULL, returning all years present in the data.
 #' @param vars A vector of strings naming columns to subset the data on.
 #'  Defaults to NULL, indicating all variables should be used.
 #'

--- a/man/build_tbl.Rd
+++ b/man/build_tbl.Rd
@@ -41,7 +41,14 @@ performing a series of cascading joins on matching keys.
 \dontrun{
 build_tbl(
   "tb",
-  2019,
+  year = 2019,
+  estimated = "who_estimates.e_inc_num",
+  notified = "who_notifications.c_newinc",
+  c("year", "country_code", "pop_density", "e_inc_num", "c_newinc")
+)
+build_tbl(
+  "tb",
+  year = 2019:2018,
   estimated = "who_estimates.e_inc_num",
   notified = "who_notifications.c_newinc",
   c("year", "country_code", "pop_density", "e_inc_num", "c_newinc")

--- a/man/build_tbl.Rd
+++ b/man/build_tbl.Rd
@@ -23,8 +23,8 @@ for DX Gap computation. If kept to \code{NULL}, the function will use the value
 \code{notifications_table.notifications_field} from the \code{notified} column in the
 \code{dxgap_diseases} meta table.}
 
-\item{year}{An integer indicating a year to filter the data on. Defaults to
-NULL, returning all years present in the data.}
+\item{year}{An integer vector indicating consecutive years to filter the
+data on. Defaults to NULL, returning all years present in the data.}
 
 \item{vars}{A vector of strings naming columns to subset the data on.
 Defaults to NULL, indicating all variables should be used.}

--- a/man/render_bulk.Rd
+++ b/man/render_bulk.Rd
@@ -34,8 +34,8 @@ for DX Gap computation. If kept to \code{NULL}, the function will use the value
 \code{notifications_table.notifications_field} from the \code{notified} column in the
 \code{dxgap_diseases} meta table.}
 
-\item{year}{An integer indicating a year to filter the data on. Defaults to
-NULL, returning all years present in the data.}
+\item{year}{An integer vector indicating consecutive years to filter the
+data on. Defaults to NULL, returning all years present in the data.}
 
 \item{vars}{A vector of strings naming columns to subset the data on. Passed
 to \code{\link[=build_tbl]{build_tbl()}}. Defaults to NULL, indicating all variables should be

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -15,3 +15,32 @@
       ! `0` values found in `am`.
       i Dividing by `0` generates `Inf` values.
 
+# check_supported_year() works
+
+    Code
+      check_supported_year(2014:2015, "tb")
+    Condition
+      Error in `check_supported_year()`:
+      ! `2014, 2015` not in supported year range for disease `tb`.
+
+---
+
+    Code
+      check_supported_year(2014:2016, "tb")
+    Message
+      `2014, 2015` not in supported year range for disease `tb`.
+      i Fallback on: `2016`.
+
+---
+
+    Code
+      check_supported_year(2020:2023, "tb")
+    Message
+      `2022, 2023` not in supported year range for disease `tb`.
+      i Fallback on: `2020, 2021`.
+
+---
+
+    Code
+      check_supported_year(2016:2021, "tb")
+

--- a/tests/testthat/test-build_dm.R
+++ b/tests/testthat/test-build_dm.R
@@ -39,6 +39,56 @@ test_that("build_dm() works and returns a time series", {
   })
 })
 
+test_that("build_dm()'s year arg. works", {
+  skip_on_ci()
+  skip_if(Sys.getenv("DXGAP_DATADIR") == "")
+  data_list <- build_lst("tb")
+  dm <- build_dm(
+    data_list,
+    estimated = "who_estimates.e_inc_num",
+    notified = "who_notifications.c_newinc",
+    year = 2018:2021
+  )
+  years <- unique(dm$country$year)
+  expect_length(years, 4)
+  dm <- build_dm(
+    data_list,
+    estimated = "who_estimates.e_inc_num",
+    notified = "who_notifications.c_newinc",
+    year = 2021
+  )
+  years <- unique(dm$country$year)
+  expect_length(years, 1)
+  dm <- build_dm(
+    data_list,
+    estimated = "who_estimates.e_inc_num",
+    notified = "who_notifications.c_newinc",
+    year = NULL
+  )
+  years <- unique(dm$country$year)
+  expect_true(length(years) > 0)
+  expect_error(
+    dm <- build_dm(
+      data_list,
+      estimated = "who_estimates.e_inc_num",
+      notified = "who_notifications.c_newinc",
+      year = 2014
+    ),
+    regexp = "not in",
+    class = "dxgap_year_supported_range"
+  )
+  expect_message(
+    dm <- build_dm(
+      data_list,
+      estimated = "who_estimates.e_inc_num",
+      notified = "who_notifications.c_newinc",
+      year = 2014:2017
+    ),
+    regexp = "Fallback",
+    class = "dxgap_year_supported_range"
+  )
+})
+
 test_that("build_dm() with `NULL` args.", {
   skip_on_ci()
   skip_if(Sys.getenv("DXGAP_DATADIR") == "")

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -20,3 +20,10 @@ test_that("check_any_zero() works", {
   df <- datasets::mtcars
   expect_snapshot(check_any_zero(df, am), error = TRUE)
 })
+
+test_that("check_supported_year() works", {
+  expect_snapshot(check_supported_year(2014:2015, "tb"), error = TRUE)
+  expect_snapshot(check_supported_year(2014:2016, "tb"))
+  expect_snapshot(check_supported_year(2020:2023, "tb"))
+  expect_snapshot(check_supported_year(2016:2021, "tb"))
+})


### PR DESCRIPTION
- We can now call `build_tbl("tb", year = 2019:2018)` and not just `build_tbl("tb", year = 2019)` or `build_tbl("tb", year = NULL)`.
- If any of the years passed by the users are not supported (not in the data) we fall back on just those that are available.
- Enhanced `check_supported_year()`.