### PR TITLE
Raise an error when it is not possible to find a subset of countries to compute `dx_gap`

### DIFF
--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -52,7 +52,8 @@ build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) 
   core_data <- get_core(
     data_list,
     estimated = estimated,
-    notified = notified
+    notified = notified,
+    year = year
   )
   core_list <- core_data$core_list
   can_compute_dxgap <- core_data$can_compute_dxgap

--- a/R/check.R
+++ b/R/check.R
@@ -224,15 +224,15 @@ check_interactive_render <- function(year, interactive) {
   }
 }
 
-check_valid_core_subset <- function(data, var, start_year) {
+check_valid_core_subset <- function(data, var, year) {
   vec <- data$country_code
   if (rlang::is_bare_character(vec, 0)) {
     rlang::abort(
       c(
         sprintf(
-          "Cannot find a valid 'core' subset of countries for which `%s` is consecutively not `NA` from `%s`.",
+          "Cannot find a valid 'core' subset of countries for which `%s` is consecutively not `NA` in year(s) `%s`.",
           var,
-          start_year
+          to_chr_range(year)
         ),
         i = sprintf("Possible reason is `%s` low completion rate.", var),
         i = "A 'core' valid subset may still be found tweaking the `year` range."

--- a/R/check.R
+++ b/R/check.R
@@ -223,3 +223,21 @@ check_interactive_render <- function(year, interactive) {
     )
   }
 }
+
+check_valid_core_subset <- function(data, var, start_year) {
+  vec <- data$country_code
+  if (rlang::is_bare_character(vec, 0)) {
+    rlang::abort(
+      c(
+        sprintf(
+          "Cannot find a valid 'core' subset of countries for which `%s` is consecutively not `NA` from `%s`.",
+          var,
+          start_year
+        ),
+        i = sprintf("Possible reason is `%s` low completion rate.", var),
+        i = "A 'core' valid subset may still be found tweaking the `year` range."
+      ),
+      class = "dxgap_data"
+    )
+  }
+}

--- a/R/core.R
+++ b/R/core.R
@@ -8,7 +8,7 @@
 #'   notified = "who_notifications.c_newinc"
 #' )
 #' }
-get_core <- function(data_list, estimated, notified) {
+get_core <- function(data_list, estimated, notified, year) {
   disease <- attr(data_list, "disease")
   min_year <- extract_start_year(disease = disease)
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
@@ -26,7 +26,7 @@ get_core <- function(data_list, estimated, notified) {
       start_year = min_year
     )
 
-  check_valid_core_subset(country_notification_df, var = notified_field_name, start_year = min_year)
+  check_valid_core_subset(country_notification_df, var = notified_field_name, start_year = min(year))
 
   country_estimate_df <-
     data_list |>
@@ -37,7 +37,7 @@ get_core <- function(data_list, estimated, notified) {
       start_year = min_year
     )
 
-  check_valid_core_subset(country_estimate_df, var = notified_field_name, start_year = min_year)
+  check_valid_core_subset(country_estimate_df, var = notified_field_name, start_year = min(year))
 
   in_common_dxgap <-
     country_notification_df |>

--- a/R/core.R
+++ b/R/core.R
@@ -26,6 +26,8 @@ get_core <- function(data_list, estimated, notified) {
       start_year = min_year
     )
 
+  check_valid_core_subset(country_notification_df, var = notified_field_name, start_year = min_year)
+
   country_estimate_df <-
     data_list |>
     purrr::pluck(estimated_tbl_name) |>
@@ -34,6 +36,8 @@ get_core <- function(data_list, estimated, notified) {
       !!rlang::ensym(estimated_field_name),
       start_year = min_year
     )
+
+  check_valid_core_subset(country_estimate_df, var = notified_field_name, start_year = min_year)
 
   in_common_dxgap <-
     country_notification_df |>

--- a/R/core.R
+++ b/R/core.R
@@ -26,7 +26,7 @@ get_core <- function(data_list, estimated, notified, year) {
       start_year = min_year
     )
 
-  check_valid_core_subset(country_notification_df, var = notified_field_name, start_year = min(year))
+  check_valid_core_subset(country_notification_df, var = notified_field_name, year = year)
 
   country_estimate_df <-
     data_list |>
@@ -37,7 +37,7 @@ get_core <- function(data_list, estimated, notified, year) {
       start_year = min_year
     )
 
-  check_valid_core_subset(country_estimate_df, var = notified_field_name, start_year = min(year))
+  check_valid_core_subset(country_estimate_df, var = notified_field_name, year = year)
 
   in_common_dxgap <-
     country_notification_df |>

--- a/R/help.R
+++ b/R/help.R
@@ -243,3 +243,9 @@ relocate_dx_gap <- function(tbl) {
 strip_ext <- function(file_name) {
   stringr::str_remove(file_name, "\\..*$")
 }
+
+to_chr_range <- function(num_vec) {
+  min_yr <- min(num_vec)
+  max_yr <- max(num_vec)
+  paste(c(min_yr, max_yr), collapse = " - ")
+}


### PR DESCRIPTION
Need to review these cases.

``` r
library(find.dxgap)

build_tbl(
  "tb",
  year = 2016:2021,
  vars = c("year", "country_code", "pop_density", "e_inc_num", "conf_rrmdr_tx", "c_newinc"),
  estimated = "who_estimates.e_inc_num",
  notified = "who_notifications.conf_rrmdr_tx",
)
#> Error in `check_valid_core_subset()` at find.dxgap/R/core.R:32:5:
#> ! Cannot find a valid 'core' subset of countries for which `conf_rrmdr_tx` is consecutively not `NA` form the inferior limit of `year`.
#> ℹ Possible reason is `conf_rrmdr_tx`'s low completion rate.
#> ℹ You might find a valid 'core' subset by tweaking the inferior limit of `year`.
#> ℹ Pass `override_core_check = list('notified' = TRUE, 'estimated' = TRUE)` if you want to skip this check for one or all the variables.
#> Backtrace:
#>     ▆
#>  1. └─find.dxgap::build_tbl(...)
#>  2.   └─find.dxgap:::build_dm(...) at find.dxgap/R/build_tbl.R:61:3
#>  3.     └─find.dxgap:::get_core(...) at find.dxgap/R/build_dm.R:56:3
#>  4.       └─find.dxgap:::check_valid_core_subset(country_notification_df, var = notified_field_name) at find.dxgap/R/core.R:32:5
#>  5.         └─rlang::abort(...) at find.dxgap/R/check.R:230:5

build_tbl(
  "tb",
  year = 2016:2021,
  vars = c("year", "country_code", "pop_density", "e_inc_num", "conf_rrmdr_tx", "c_newinc"),
  estimated = "who_estimates.e_inc_num",
  notified = "who_notifications.conf_rrmdr_tx",
  override_core_check = list('notified' = TRUE, 'estimated' = FALSE)
)
#> Error in `check_valid_core_subset()` at find.dxgap/R/core.R:45:5:
#> ! Cannot find a valid 'core' subset of countries for which `e_inc_num` is consecutively not `NA` form the inferior limit of `year`.
#> ℹ Possible reason is `e_inc_num`'s low completion rate.
#> ℹ You might find a valid 'core' subset by tweaking the inferior limit of `year`.
#> ℹ Pass `override_core_check = list('notified' = TRUE, 'estimated' = TRUE)` if you want to skip this check for one or all the variables.
#> Backtrace:
#>     ▆
#>  1. └─find.dxgap::build_tbl(...)
#>  2.   └─find.dxgap:::build_dm(...) at find.dxgap/R/build_tbl.R:61:3
#>  3.     └─find.dxgap:::get_core(...) at find.dxgap/R/build_dm.R:56:3
#>  4.       └─find.dxgap:::check_valid_core_subset(country_notification_df, var = estimated_field_name) at find.dxgap/R/core.R:45:5
#>  5.         └─rlang::abort(...) at find.dxgap/R/check.R:230:5

build_tbl(
  "tb",
  year = 2016:2021,
  vars = c("year", "country_code", "pop_density", "e_inc_num", "conf_rrmdr_tx", "c_newinc"),
  estimated = "who_estimates.e_inc_num",
  notified = "who_notifications.conf_rrmdr_tx",
  override_core_check = list('notified' = FALSE, 'estimated' = TRUE)
)
#> Error in `check_valid_core_subset()` at find.dxgap/R/core.R:32:5:
#> ! Cannot find a valid 'core' subset of countries for which `conf_rrmdr_tx` is consecutively not `NA` form the inferior limit of `year`.
#> ℹ Possible reason is `conf_rrmdr_tx`'s low completion rate.
#> ℹ You might find a valid 'core' subset by tweaking the inferior limit of `year`.
#> ℹ Pass `override_core_check = list('notified' = TRUE, 'estimated' = TRUE)` if you want to skip this check for one or all the variables.
#> Backtrace:
#>     ▆
#>  1. └─find.dxgap::build_tbl(...)
#>  2.   └─find.dxgap:::build_dm(...) at find.dxgap/R/build_tbl.R:61:3
#>  3.     └─find.dxgap:::get_core(...) at find.dxgap/R/build_dm.R:56:3
#>  4.       └─find.dxgap:::check_valid_core_subset(country_notification_df, var = notified_field_name) at find.dxgap/R/core.R:32:5
#>  5.         └─rlang::abort(...) at find.dxgap/R/check.R:230:5

build_tbl(
  "tb",
  year = 2016:2021,
  vars = c("year", "country_code", "pop_density", "e_inc_num", "conf_rrmdr_tx", "c_newinc"),
  estimated = "who_estimates.e_inc_num",
  notified = "who_notifications.conf_rrmdr_tx",
  override_core_check = list('notified' = TRUE, 'estimated' = TRUE)
)
#> Error in `check_any_na()` at find.dxgap/R/check.R:203:3:
#> ! `NA` values found in `e_inc_num`.
#> Backtrace:
#>     ▆
#>  1. └─find.dxgap::build_tbl(...)
#>  2.   └─find.dxgap:::build_tbl_impl(...) at find.dxgap/R/build_tbl.R:86:3
#>  3.     └─find.dxgap::compute_dx_gap(...) at find.dxgap/R/build_tbl.R:123:3
#>  4.       └─find.dxgap:::check_any_zero(data, !!est) at find.dxgap/R/compute.R:44:3
#>  5.         └─find.dxgap:::check_any_na(data = data, var = !!var_quote) at find.dxgap/R/check.R:203:3
#>  6.           └─rlang::abort(sprintf("`NA` values found in `%s`.", rlang::as_name(var_quote))) at find.dxgap/R/check.R:197:5
```

<sup>Created on 2024-01-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>