### PR TITLE
Add `notified` and `estimated` fields automatically to `vars`

### DIFF
--- a/R/build_tbl.R
+++ b/R/build_tbl.R
@@ -117,7 +117,7 @@ build_tbl_impl <- function(dm, estimated, notified, vars = NULL) {
     dplyr::relocate(is_hbc, country_code, year, .before = everything())
 
   if (!is.null(vars)) {
-    vars_dx_gap <- c(vars, "dx_gap", estimated, notified)
+    vars_dx_gap <- unique(c(vars, "dx_gap", estimated, notified))
     tbl <-
       tbl |>
       dplyr::select(tidyselect::any_of(vars_dx_gap))

--- a/R/build_tbl.R
+++ b/R/build_tbl.R
@@ -117,7 +117,7 @@ build_tbl_impl <- function(dm, estimated, notified, vars = NULL) {
     dplyr::relocate(is_hbc, country_code, year, .before = everything())
 
   if (!is.null(vars)) {
-    vars_dx_gap <- c(vars, "dx_gap")
+    vars_dx_gap <- c(vars, "dx_gap", estimated, notified)
     tbl <-
       tbl |>
       dplyr::select(tidyselect::any_of(vars_dx_gap))


### PR DESCRIPTION
If I forgot to add estimated and notified to vars, those are added automatically.

``` r
library(find.dxgap)
build_tbl(
  "tb",
  year = 2019:2018,
  estimated = "who_estimates.e_inc_num",
  notified = "who_notifications.c_newinc",
  vars = c("year", "country_code", "pop_density")
)
#> # A tibble: 386 × 6
#>     year country_code dx_gap pop_density e_inc_num c_newinc
#>    <dbl> <chr>         <dbl>       <dbl>     <dbl>    <dbl>
#>  1  2018 AGO           40.4        25.1     111000    66189
#>  2  2019 AGO           35.0        26.0     114000    74105
#>  3  2018 BGD           26.2      1257.      362000   267143
#>  4  2019 BGD           20.3      1272.      366000   291595
#>  5  2018 BRA           11.3        25.1      96000    85108
#>  6  2019 BRA           10.9        25.3      96000    85523
#>  7  2018 CAF           61.1         8.18     28000    10881
#>  8  2019 CAF           57.0         8.36     28000    12046
#>  9  2018 CHN            7.53      149.      860000   795245
#> 10  2019 CHN           11.8       150.      826000   728265
#> # ℹ 376 more rows
```

<sup>Created on 2024-01-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>