### PR TITLE
`year` can be NULL in `get_core()`

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -10,7 +10,11 @@
 #' }
 get_core <- function(data_list, estimated, notified, year) {
   disease <- attr(data_list, "disease")
-  min_year <- extract_start_year(disease = disease)
+  if (is.null(year)) {
+    year <- extract_supported_year(disease = disease)
+    min_year <- min(year)
+  }
+  min_year <- min(year)
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
 
   estimated_tbl_name <- extract_tbl_name(dxgap_meta_df, "estimated")


### PR DESCRIPTION

``` r
pkgload::load_all()
#> ℹ Loading find.dxgap
try(
  build_tbl(
    "tb",
    vars = c("country_code", "year"),
    estimated = dxgap_diseases$estimated,
    notified = "who_notifications.conf_rrmdr_tx",
    year = 2018:2021
  )
)
#> Error in check_valid_core_subset(country_notification_df, var = notified_field_name,  : 
#>   Cannot find a valid 'core' subset of countries for which `conf_rrmdr_tx` is consecutively not `NA` in year(s) `2018 - 2021`.
#> ℹ Possible reason is `conf_rrmdr_tx` low completion rate.
#> ℹ A 'core' valid subset may still be found tweaking the `year` range.

try(
  build_tbl(
    "tb",
    vars = c("country_code", "year"),
    estimated = dxgap_diseases$estimated,
    notified = "who_notifications.conf_rrmdr_tx",
    year = NULL # takes the default supported years in dxgap_diseases `start_year` and `end_year`
  )
)
#> Error in check_valid_core_subset(country_notification_df, var = notified_field_name,  : 
#>   Cannot find a valid 'core' subset of countries for which `conf_rrmdr_tx` is consecutively not `NA` in year(s) `2016 - 2021`.
#> ℹ Possible reason is `conf_rrmdr_tx` low completion rate.
#> ℹ A 'core' valid subset may still be found tweaking the `year` range.
```

<sup>Created on 2024-03-19 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>