### PR TITLE
Return fallback year invisibly in `check_supported_year()` range 

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -96,6 +96,7 @@ check_supported_year <- function(year, disease, .dxgap_diseases = dxgap_diseases
       ),
       class = "dxgap_year_supported_range"
     )
+    return(invisible(fall_back_range))
   } else {
     invisible(year)
   }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -24,6 +24,8 @@ test_that("check_any_zero() works", {
 test_that("check_supported_year() works", {
   expect_snapshot(check_supported_year(2014:2015, "tb"), error = TRUE)
   expect_snapshot(check_supported_year(2014:2016, "tb"))
+  expect_invisible(check_supported_year(2014:2016, "tb"), 2016)
   expect_snapshot(check_supported_year(2020:2023, "tb"))
   expect_snapshot(check_supported_year(2016:2021, "tb"))
+  expect_invisible(check_supported_year(2016:2021, "tb"), 2016:2021)
 })


### PR DESCRIPTION
We can use the returned range in `get_core()` then.