### PR TITLE
Refactor `get_core()`

### DIFF
--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -31,9 +31,6 @@
 build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) {
   disease <- attr(data_list, "disease")
   check_supported_year(year = year, disease = disease)
-  supported_year_range <- extract_supported_year(disease = disease)
-  max_year <- max(supported_year_range)
-  min_year <- min(supported_year_range)
 
   if (is.null(estimated)) {
     estimated <- extract_default_dxgap_tbl_field(

--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -111,6 +111,7 @@ set_dm_colors <- function(dm) {
     dm::dm_set_colors(
       "#5986C4" = starts_with("who"),
       "#70AD47FF" = starts_with("wb"),
-      "#ED7D31FF" = contains("country")
+      "#ED7D31FF" = contains("country"),
+      "#E15759" = contains("hbc")
     )
 }

--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -71,6 +71,7 @@ set_dm_rels <- function(dm) {
 
 set_dm_pk <- function(dm) {
   dm |>
+    dm::dm_add_pk(hbc, country_code, check = TRUE) |>
     dm::dm_add_pk(wb_pop_total, c(year, country_code), check = TRUE) |>
     dm::dm_add_pk(wb_pop_urban, c(year, country_code), check = TRUE) |>
     dm::dm_add_pk(wb_pop_density, c(year, country_code), check = TRUE) |>
@@ -86,6 +87,7 @@ set_dm_pk <- function(dm) {
 
 set_dm_fk <- function(dm) {
   dm |>
+    dm::dm_add_fk(country, country_code, hbc) |>
     dm::dm_add_fk(country, c(year, country_code), wb_pop_total) |>
     dm::dm_add_fk(country, c(year, country_code), wb_pop_urban) |>
     dm::dm_add_fk(country, c(year, country_code), wb_pop_density) |>

--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -46,60 +46,20 @@ build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) 
       dxgap_field = "notified"
     )
   }
-  core_data <- get_core(
+
+  core_lst <- get_core(
     data_list,
     estimated = estimated,
     notified = notified,
     year = year
   )
-  core_list <- core_data$core_list
-  can_compute_dxgap <- core_data$can_compute_dxgap
 
-  hbc_df <-
-    data_list$who_hbc |>
-    dplyr::select(country_code, year) |>
-    forget_year_hbc(year_range = supported_year_range) |>
-    dplyr::mutate(is_hbc = 1)
-
-  non_hbc_df <-
-    get_non_hbc_country_code(hbc_df, start_year = min_year) |>
-    dplyr::semi_join(can_compute_dxgap, dplyr::join_by(country_code)) |>
-    dplyr::mutate(is_hbc = 0)
-
-  # estimates and notifications are available up to given year
-  country_df <-
-    hbc_df |>
-    dplyr::bind_rows(non_hbc_df) |>
-    dplyr::filter(year <= max_year)
-
-  core_list$who_hbc <- NULL
-  core_list$country <- country_df
-
-  dm_no_rel <- dm::dm(!!!core_list)
+  dm_no_rel <- dm::dm(!!!core_lst)
   dm_col <- set_dm_colors(dm_no_rel)
-  dm_ts <- set_dm_rels(dm_col)
+  dm_disease <- set_dm_rels(dm_col)
 
-  if (is.null(year)) {
-    return(dm_ts)
-  }
+  dm_disease
 
-  dm::dm_filter(dm_ts, country = (year %in% !!year))
-
-}
-
-forget_year_hbc <- function(hbc_data, year_range) {
-  hbc_data |>
-    dplyr::select(-year) |>
-    tidyr::crossing(year = year_range)
-}
-
-get_non_hbc_country_code <- function(hbc_df, start_year) {
-  countrycode::codelist |>
-    dplyr::select(country_code = iso3c) |>
-    dplyr::filter(!is.na(country_code)) |>
-    dplyr::anti_join(hbc_df, by = dplyr::join_by(country_code)) |>
-    dplyr::anti_join(country_exclude_df, by = dplyr::join_by(country_code)) |>
-    tidyr::crossing(year = start_year:2099) # start from the min year available in hbc list
 }
 
 set_dm_rels <- function(dm) {

--- a/R/build_dm.R
+++ b/R/build_dm.R
@@ -30,7 +30,7 @@
 #' }
 build_dm <- function(data_list, estimated = NULL, notified = NULL, year = NULL) {
   disease <- attr(data_list, "disease")
-  check_supported_year(year = year, disease = disease)
+  year <- check_supported_year(year = year, disease = disease)
 
   if (is.null(estimated)) {
     estimated <- extract_default_dxgap_tbl_field(

--- a/R/core.R
+++ b/R/core.R
@@ -91,9 +91,7 @@ get_core <- function(data_list, estimated, notified, year) {
   cc_core_df <-
     cc_can_compute_dxgap |>
     dplyr::bind_rows(cc_consistent_hbc) |>
-    tidyr::crossing(year = year) #|>
-    # dplyr::left_join(core_hbc_df, by = join_by(country_code, year)) |>
-    # dplyr::mutate(is_hbc = coalesce(is_hbc, 0))
+    tidyr::crossing(year = year)
 
   # create is_hbc table
   is_hbc <-
@@ -124,23 +122,6 @@ get_core <- function(data_list, estimated, notified, year) {
       )
     ) |>
     dplyr::select(name, data_core)
-
-  # # create binary `is_hbc`
-  # core_df_is_hbc <-
-  #   core_df |>
-  #   dplyr::mutate(
-  #     data_core_is_hbc = purrr::map(
-  #       data_core,
-  #       ~ dplyr::left_join(.x, core_hbc_df, dplyr::join_by(country_code, year))
-  #     )
-  #   ) |>
-  #   dplyr::mutate(
-  #     data_core_is_hbc = purrr::map(
-  #       data_core_is_hbc,
-  #       ~ dplyr::mutate(.x, is_hbc = dplyr::coalesce(is_hbc, 0))
-  #     )
-  #   ) |>
-  #   dplyr::select(name, data_core_is_hbc)
 
   core_lst <- core_df$data_core
   names(core_lst) <- core_df$name

--- a/R/core.R
+++ b/R/core.R
@@ -82,10 +82,10 @@ get_cc_always_given_acrs_yrs <- function(data) {
 }
 
 
-get_cc_var_always_given_acrs_yrs <- function(data, var, start_year) {
+get_cc_var_always_given_acrs_yrs <- function(data, var, year_range) {
   check_is_ts(data)
   data |>
-    dplyr::filter(year >= !!start_year) |>
+    dplyr::filter(dplyr::between(year, min(year_range), max(year_range))) |>
     dplyr::mutate(is_given = !is.na({{ var }})) |>
     dplyr::select(country_code, year, is_given) |>
     dplyr::group_split(year, .keep = FALSE) |>

--- a/R/core.R
+++ b/R/core.R
@@ -6,7 +6,19 @@
 #'   build_lst("tb"),
 #'   estimated = "who_estimates.e_inc_num",
 #'   notified = "who_notifications.c_newinc",
+#'   year = 2019
+#' )
+#' get_core(
+#'   build_lst("tb"),
+#'   estimated = "who_estimates.e_inc_num",
+#'   notified = "who_notifications.c_newinc",
 #'   year = NULL
+#' )
+#' get_core(
+#'   build_lst("tb"),
+#'   estimated = "who_estimates.e_inc_num",
+#'   notified = "who_notifications.c_newinc",
+#'   year = 2019:2021
 #' )
 #' }
 get_core <- function(data_list, estimated, notified, year) {
@@ -14,6 +26,7 @@ get_core <- function(data_list, estimated, notified, year) {
   if (is.null(year)) {
     year <- extract_supported_year(disease = disease)
   }
+
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
 
   estimated_tbl_name <- extract_tbl_name(dxgap_meta_df, "estimated")

--- a/R/core.R
+++ b/R/core.R
@@ -34,12 +34,11 @@
 #' )
 #' }
 get_core <- function(data_list, estimated, notified, year) {
-
   disease <- attr(data_list, "disease")
   if (is.null(year)) {
     year <- extract_supported_year(disease = disease)
   }
-  check_supported_year(year = year, disease = disease)
+  year <- check_supported_year(year = year, disease = disease)
 
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
 

--- a/R/core.R
+++ b/R/core.R
@@ -34,8 +34,7 @@ get_core <- function(data_list, estimated, notified, year) {
   notified_tbl_name <- extract_tbl_name(dxgap_meta_df, "notified")
   notified_field_name <- extract_field_name(dxgap_meta_df, "notified")
 
-  # Subset of countries for which dx_gap can be computed in `year` range -------
-  country_notification_df <-
+  cc_notification_df <-
     data_list |>
     purrr::pluck(notified_tbl_name) |>
     get_cc_var_always_given_acrs_yrs(
@@ -43,9 +42,9 @@ get_core <- function(data_list, estimated, notified, year) {
       year_range = year
     )
 
-  check_valid_core_subset(country_notification_df, var = notified_field_name, year = year)
+  check_valid_core_subset(cc_notification_df, var = notified_field_name, year = year)
 
-  country_estimate_df <-
+  cc_estimate_df <-
     data_list |>
     purrr::pluck(estimated_tbl_name) |>
     dplyr::filter(!!rlang::ensym(estimated_field_name) != 0) |> # avoid dividing by zero

--- a/R/core.R
+++ b/R/core.R
@@ -101,16 +101,18 @@ get_core <- function(data_list, estimated, notified, year) {
 
   data_list$who_hbc <- NULL
 
-  # create base table "country"
+  # create parent table "country"
   cc_core_df <-
     cc_can_compute_dxgap |>
     dplyr::bind_rows(cc_consistent_hbc) |>
     tidyr::crossing(year = year)
 
-  # create is_hbc table
   is_hbc <-
     cc_core_df |>
-    dplyr::left_join(core_hbc_df, by = dplyr::join_by(country_code, year)) |>
+    dplyr::left_join(
+      dplyr::distinct(core_hbc_df, country_code, is_hbc),
+      by = dplyr::join_by(country_code)
+    ) |>
     dplyr::mutate(is_hbc = dplyr::coalesce(is_hbc, 0)) |>
     dplyr::distinct(country_code, is_hbc)
 

--- a/R/core.R
+++ b/R/core.R
@@ -14,7 +14,6 @@ get_core <- function(data_list, estimated, notified, year) {
   if (is.null(year)) {
     year <- extract_supported_year(disease = disease)
   }
-  min_year <- min(year)
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
 
   estimated_tbl_name <- extract_tbl_name(dxgap_meta_df, "estimated")

--- a/R/core.R
+++ b/R/core.R
@@ -91,16 +91,16 @@ get_core <- function(data_list, estimated, notified, year) {
   cc_core_df <-
     cc_can_compute_dxgap |>
     dplyr::bind_rows(cc_consistent_hbc) |>
-    tidyr::crossing(year = year) |>
-    dplyr::left_join(core_hbc_df, by = join_by(country_code, year)) |>
-    dplyr::mutate(is_hbc = coalesce(is_hbc, 0))
+    tidyr::crossing(year = year) #|>
+    # dplyr::left_join(core_hbc_df, by = join_by(country_code, year)) |>
+    # dplyr::mutate(is_hbc = coalesce(is_hbc, 0))
 
-  # # create is_hbc table
-  # is_hbc <-
-  #   cc_core_df |>
-  #   dplyr::left_join(core_hbc_df, by = join_by(country_code, year)) |>
-  #   dplyr::mutate(is_hbc = coalesce(is_hbc, 0)) |>
-  #   distinct(country_code, is_hbc)
+  # create is_hbc table
+  is_hbc <-
+    cc_core_df |>
+    dplyr::left_join(core_hbc_df, by = dplyr::join_by(country_code, year)) |>
+    dplyr::mutate(is_hbc = dplyr::coalesce(is_hbc, 0)) |>
+    dplyr::distinct(country_code, is_hbc)
 
   # used to subset those cc for which dx_gap can always be computed *and*
   # that are consistently hbc in the given year range
@@ -145,7 +145,7 @@ get_core <- function(data_list, estimated, notified, year) {
   core_lst <- core_df$data_core
   names(core_lst) <- core_df$name
   core_lst$country <- cc_core_df
-  # core_lst$is_hbc <- is_hbc
+  core_lst$hbc <- is_hbc
   core_lst
 }
 

--- a/R/core.R
+++ b/R/core.R
@@ -20,6 +20,12 @@
 #'   notified = "who_notifications.c_newinc",
 #'   year = 2019:2021
 #' )
+#' get_core(
+#'   build_lst("tb"),
+#'   estimated = "who_estimates.e_inc_num",
+#'   notified = "who_notifications.c_newinc",
+#'   year = 2014:2017
+#' )
 #' }
 get_core <- function(data_list, estimated, notified, year) {
   disease <- attr(data_list, "disease")

--- a/R/core.R
+++ b/R/core.R
@@ -26,12 +26,20 @@
 #'   notified = "who_notifications.c_newinc",
 #'   year = 2014:2017
 #' )
+#' get_core(
+#'   build_lst("tb"),
+#'   estimated = "who_estimates.e_inc_num",
+#'   notified = "who_notifications.c_newinc",
+#'   year = 2013:2014
+#' )
 #' }
 get_core <- function(data_list, estimated, notified, year) {
+
   disease <- attr(data_list, "disease")
   if (is.null(year)) {
     year <- extract_supported_year(disease = disease)
   }
+  check_supported_year(year = year, disease = disease)
 
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
 

--- a/R/core.R
+++ b/R/core.R
@@ -21,6 +21,7 @@ get_core <- function(data_list, estimated, notified, year) {
   notified_tbl_name <- extract_tbl_name(dxgap_meta_df, "notified")
   notified_field_name <- extract_field_name(dxgap_meta_df, "notified")
 
+  # Subset of countries for which dx_gap can be computed in `year` range -------
   country_notification_df <-
     data_list |>
     purrr::pluck(notified_tbl_name) |>
@@ -48,7 +49,7 @@ get_core <- function(data_list, estimated, notified, year) {
 
   subset_df <-
     to_nest_df(data_list) |>
-    dplyr::mutate( # get core set of consistently hbc across year
+    dplyr::mutate( # get core set of consistently hbc countries across year
       consistently_hbc = dplyr::if_else(
         stringr::str_detect(name, "hbc"),
         purrr::map(data, get_cc_always_given_acrs_yrs),

--- a/R/core.R
+++ b/R/core.R
@@ -13,7 +13,6 @@ get_core <- function(data_list, estimated, notified, year) {
   disease <- attr(data_list, "disease")
   if (is.null(year)) {
     year <- extract_supported_year(disease = disease)
-    min_year <- min(year)
   }
   min_year <- min(year)
   dxgap_meta_df <- get_meta_dxgap(estimated = estimated, notified = notified)
@@ -28,7 +27,7 @@ get_core <- function(data_list, estimated, notified, year) {
     purrr::pluck(notified_tbl_name) |>
     get_cc_var_always_given_acrs_yrs(
       !!rlang::ensym(notified_field_name),
-      start_year = min_year
+      year_range = year
     )
 
   check_valid_core_subset(country_notification_df, var = notified_field_name, year = year)
@@ -39,7 +38,7 @@ get_core <- function(data_list, estimated, notified, year) {
     dplyr::filter(!!rlang::ensym(estimated_field_name) != 0) |> # avoid dividing by zero
     get_cc_var_always_given_acrs_yrs(
       !!rlang::ensym(estimated_field_name),
-      start_year = min_year
+      year_range = year
     )
 
   check_valid_core_subset(country_estimate_df, var = estimated_field_name, year = year)

--- a/R/core.R
+++ b/R/core.R
@@ -143,7 +143,6 @@ get_cc_always_given_acrs_yrs <- function(data) {
 
 
 get_cc_var_always_given_acrs_yrs <- function(data, var, year_range) {
-  check_is_ts(data)
   data |>
     dplyr::filter(dplyr::between(year, min(year_range), max(year_range))) |>
     dplyr::mutate(is_given = !is.na({{ var }})) |>

--- a/tests/testthat/_snaps/build_dm.md
+++ b/tests/testthat/_snaps/build_dm.md
@@ -3,82 +3,82 @@
     Code
       dm::glimpse(dm)
     Output
-      dm of 12 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
+      dm of 13 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
       
       --------------------------------------------------------------------------------
       
       Table: `gf_procurement`
       Primary key: (`year`, `country_code`)
       
-      Rows: 39
+      Rows: 41
       Columns: 3
-      $ country_code      <chr> "ALB", "BDI", "BFA", "BLR", "BLZ", "BTN", "COG", "ER~
+      $ country_code      <chr> "ALB", "BDI", "BFA", "BLR", "BLZ", "BTN", "COG", "CO~
       $ year              <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019~
-      $ total_numb_device <dbl> 2002, 9300, 310000, 3360, 850, 2552, 3450, 17693, 18~
+      $ total_numb_device <dbl> 2002, 9300, 310000, 3360, 850, 2552, 3450, 2, 17693,~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_gdp`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ gdp          <dbl> 1.890450e+10, 1.540183e+10, 1.717603e+11, 3.155149e+09, 6~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ gdp          <dbl> 1.890450e+10, 1.540183e+10, 1.717603e+11, 6.470000e+08, 3~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_density`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ pop_density  <dbl> 57.908252, 104.167555, 17.930316, 162.431915, 25.951382, ~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ pop_density  <dbl> 57.908252, 104.167555, 17.930316, 236.605000, 162.431915,~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_total`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ pop_total    <dbl> 37769499, 2854191, 42705368, 76343, 32353588, 44938712, 2~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ pop_total    <dbl> 37769499, 2854191, 42705368, 47321, 76343, 32353588, 4493~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_urban`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year           <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2~
-      $ country_code   <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW",~
-      $ pop_urban_perc <dbl> 25.754, 61.229, 73.189, 87.984, 66.177, 91.991, 63.219,~
+      $ country_code   <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM",~
+      $ pop_urban_perc <dbl> 25.754, 61.229, 73.189, 87.147, 87.984, 66.177, 91.991,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_budget`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 12
-      $ country_code    <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW"~
+      $ country_code    <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM"~
       $ year            <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ budget_lab      <dbl> 2797414, NA, NA, NA, 17133500, 263032, 164346, NA, NA,~
-      $ budget_oth      <dbl> 5344361, NA, NA, NA, 4000000, 0, 162174, NA, NA, NA, 1~
-      $ budget_staff    <dbl> 915527, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA, 103~
-      $ cf_lab          <dbl> 2208668, NA, NA, NA, 7216284, 263032, 164346, NA, NA, ~
-      $ cf_staff        <dbl> 871931, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA, 103~
-      $ cf_tot_domestic <dbl> 511854, NA, NA, NA, 13692478, 2510552, 74089, NA, NA, ~
-      $ cf_tot_gf       <dbl> 6533095, NA, NA, NA, 2416285, 0, 1130669, NA, NA, NA, ~
-      $ cf_tot_grnt     <dbl> 3608394, NA, NA, NA, 4000000, 0, 0, NA, NA, NA, NA, NA~
-      $ cf_tot_sources  <dbl> 13419792, NA, NA, NA, 20108763, 2510552, 1204758, NA, ~
-      $ cf_tot_usaid    <dbl> 2766449, NA, NA, NA, 0, 0, 0, NA, NA, NA, NA, NA, NA, ~
+      $ budget_lab      <dbl> 2797414, NA, NA, NA, NA, 17133500, 263032, 164346, NA,~
+      $ budget_oth      <dbl> 5344361, NA, NA, NA, NA, 4000000, 0, 162174, NA, NA, N~
+      $ budget_staff    <dbl> 915527, NA, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA,~
+      $ cf_lab          <dbl> 2208668, NA, NA, NA, NA, 7216284, 263032, 164346, NA, ~
+      $ cf_staff        <dbl> 871931, NA, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA,~
+      $ cf_tot_domestic <dbl> 511854, NA, NA, NA, NA, 13692478, 2510552, 74089, NA, ~
+      $ cf_tot_gf       <dbl> 6533095, NA, NA, NA, NA, 2416285, 0, 1130669, NA, NA, ~
+      $ cf_tot_grnt     <dbl> 3608394, NA, NA, NA, NA, 4000000, 0, 0, NA, NA, NA, NA~
+      $ cf_tot_sources  <dbl> 13419792, NA, NA, NA, NA, 20108763, 2510552, 1204758, ~
+      $ cf_tot_usaid    <dbl> 2766449, NA, NA, NA, NA, 0, 0, 0, NA, NA, NA, NA, NA, ~
       
       --------------------------------------------------------------------------------
       
@@ -102,49 +102,49 @@
       Table: `who_estimates`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 8
-      $ country_code  <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", ~
+      $ country_code  <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", ~
       $ year          <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 20~
-      $ c_cdr         <dbl> 74, 87, 81, 87, 65, 87, 84, 87, 87, 87, 79, 87, 87, 80, ~
-      $ c_newinc_100k <dbl> 139.0, 14.0, 49.0, 6.5, 229.0, 26.0, 22.0, 1.9, 5.9, 5.2~
-      $ e_inc_100k    <dbl> 189.0, 16.0, 61.0, 7.5, 351.0, 29.0, 26.0, 2.2, 6.8, 6.0~
-      $ e_inc_num     <dbl> 71000, 470, 26000, 6, 114000, 13000, 740, 2, 1700, 530, ~
-      $ e_mort_100k   <dbl> 26.00, 0.35, 6.70, 0.61, 62.00, 1.80, 1.60, 0.18, 0.24, ~
-      $ e_pop_num     <dbl> 37769499, 2873883, 42705368, 76343, 32353588, 44745520, ~
+      $ c_cdr         <dbl> 74, 87, 81, 100, 87, 65, 87, 84, 87, 87, 87, 79, 87, 87,~
+      $ c_newinc_100k <dbl> 139.0, 14.0, 49.0, 2.1, 6.5, 229.0, 26.0, 22.0, 1.9, 5.9~
+      $ e_inc_100k    <dbl> 189.0, 16.0, 61.0, 2.1, 7.5, 351.0, 29.0, 26.0, 2.2, 6.8~
+      $ e_inc_num     <dbl> 71000, 470, 26000, 1, 6, 114000, 13000, 740, 2, 1700, 53~
+      $ e_mort_100k   <dbl> 26.00, 0.35, 6.70, 0.17, 0.61, 62.00, 1.80, 1.60, 0.18, ~
+      $ e_pop_num     <dbl> 37769499, 2873883, 42705368, 47321, 76343, 32353588, 447~
       
       --------------------------------------------------------------------------------
       
       Table: `who_expenditures`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 9
-      $ country_code      <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "AB~
+      $ country_code      <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "AR~
       $ year              <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019~
-      $ rcvd_lab          <dbl> 2165197, NA, NA, NA, 784599, 0, 171472, NA, NA, NA, ~
-      $ rcvd_staff        <dbl> 1956088, NA, NA, NA, 173805, 0, 85257, NA, NA, NA, 8~
-      $ rcvd_tot_domestic <dbl> 284773, NA, NA, NA, 2856381, 2532872, 3119098, NA, N~
-      $ rcvd_tot_gf       <dbl> 6573762, NA, NA, NA, 2416285, 0, 1474278, NA, NA, NA~
-      $ rcvd_tot_grnt     <dbl> 4826365, NA, NA, NA, 120054, 0, NA, NA, NA, NA, NA, ~
-      $ rcvd_tot_sources  <dbl> 14984900, NA, NA, NA, 5392720, 2532872, 4593376, NA,~
-      $ rcvd_tot_usaid    <dbl> 3300000, NA, NA, NA, 0, 0, NA, NA, NA, NA, NA, NA, N~
+      $ rcvd_lab          <dbl> 2165197, NA, NA, NA, NA, 784599, 0, 171472, NA, NA, ~
+      $ rcvd_staff        <dbl> 1956088, NA, NA, NA, NA, 173805, 0, 85257, NA, NA, N~
+      $ rcvd_tot_domestic <dbl> 284773, NA, NA, NA, NA, 2856381, 2532872, 3119098, N~
+      $ rcvd_tot_gf       <dbl> 6573762, NA, NA, NA, NA, 2416285, 0, 1474278, NA, NA~
+      $ rcvd_tot_grnt     <dbl> 4826365, NA, NA, NA, NA, 120054, 0, NA, NA, NA, NA, ~
+      $ rcvd_tot_sources  <dbl> 14984900, NA, NA, NA, NA, 5392720, 2532872, 4593376,~
+      $ rcvd_tot_usaid    <dbl> 3300000, NA, NA, NA, NA, 0, 0, NA, NA, NA, NA, NA, N~
       
       --------------------------------------------------------------------------------
       
       Table: `who_laboratories`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 11
-      $ country_code          <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM",~
+      $ country_code          <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG",~
       $ year                  <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ culture               <dbl> 4, 1, 29, 7, 0, 148, 1, NA, NA, NA, 7, 1, NA, 5,~
+      $ culture               <dbl> 4, 1, 29, NA, 7, 0, 148, 1, NA, NA, NA, 7, 1, NA~
       $ lab_cul               <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ lab_sm                <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ smear                 <dbl> 873, 12, 240, 7, 167, 729, 25, NA, NA, NA, 55, 1~
+      $ smear                 <dbl> 873, 12, 240, NA, 7, 167, 729, 25, NA, NA, NA, 5~
       $ lab_xpert             <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ xpert                 <dbl> 47, 1, 4, 3, 22, 12, 13, NA, NA, NA, 11, 0, NA, ~
+      $ xpert                 <dbl> 47, 1, 4, NA, 3, 22, 12, 13, NA, NA, NA, 11, 0, ~
       $ m_wrd                 <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
@@ -154,22 +154,22 @@
       Table: `who_notifications`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 8
-      $ country_code    <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW"~
+      $ country_code    <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM"~
       $ year            <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ conf_rrmdr_tx   <dbl> 396, 2, NA, 0, 1523, 222, 65, 0, 29, NA, 815, 1, 2, 12~
-      $ conf_xdr_tx     <dbl> 5, 0, NA, 0, 0, 4, 12, 0, 1, NA, 186, 0, 0, 7, 287, 0,~
-      $ new_clindx      <dbl> 13698, 88, 968, NA, 32278, 2379, 142, 0, 109, 25, 872,~
-      $ ret_rel_labconf <dbl> 763, 14, 230, NA, 2299, 169, 31, NA, 38, 16, 1000, 4, ~
-      $ c_newinc        <dbl> 52438, 412, 20879, 5, 74105, 11446, 621, 2, 1502, 464,~
-      $ new_labconf     <dbl> 24358, 211, 5422, 4, 34887, 7226, 239, 1, 771, 286, 19~
+      $ conf_rrmdr_tx   <dbl> 396, 2, NA, 0, 0, 1523, 222, 65, 0, 29, NA, 815, 1, 2,~
+      $ conf_xdr_tx     <dbl> 5, 0, NA, 0, 0, 0, 4, 12, 0, 1, NA, 186, 0, 0, 7, 287,~
+      $ new_clindx      <dbl> 13698, 88, 968, 0, NA, 32278, 2379, 142, 0, 109, 25, 8~
+      $ ret_rel_labconf <dbl> 763, 14, 230, 0, NA, 2299, 169, 31, NA, 38, 16, 1000, ~
+      $ c_newinc        <dbl> 52438, 412, 20879, 1, 5, 74105, 11446, 621, 2, 1502, 4~
+      $ new_labconf     <dbl> 24358, 211, 5422, 1, 4, 34887, 7226, 239, 1, 771, 286,~
       
       --------------------------------------------------------------------------------
       
       Table: `country`
       Primary key: (`year`, `country_code`)
-      11 outgoing foreign key(s):
+      12 outgoing foreign key(s):
         (`year`, `country_code`) -> (`gf_procurement$year`, `gf_procurement$country_co...
         (`year`, `country_code`) -> (`wb_gdp$year`, `wb_gdp$country_code`) no_action
         (`year`, `country_code`) -> (`wb_pop_density$year`, `wb_pop_density$country_co...
@@ -181,12 +181,22 @@
         (`year`, `country_code`) -> (`who_expenditures$year`, `who_expenditures$countr...
         (`year`, `country_code`) -> (`who_laboratories$year`, `who_laboratories$countr...
         (`year`, `country_code`) -> (`who_notifications$year`, `who_notifications$coun...
+        `country_code` -> `hbc$country_code` no_action
       
-      Rows: 195
-      Columns: 3
-      $ country_code <chr> "AGO", "BGD", "BRA", "CAF", "CHN", "COD", "COG", "ETH", "~
-      $ year         <int> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ is_hbc       <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ~
+      Rows: 203
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
+      
+      --------------------------------------------------------------------------------
+      
+      Table: `hbc`
+      Primary key: `country_code`
+      
+      Rows: 203
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ is_hbc       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, ~
       
       --------------------------------------------------------------------------------
 
@@ -198,10 +208,10 @@
       ! Unsatisfied constraints:
     Output
       * Table `country`: foreign key `year`, `country_code` into table `gf_procurement`: values of `country$year`, `country$country_code` not in `gf_procurement$year`, `gf_procurement$country_code`: 2019, ABW (1), 2019, AFG (1), 2019, AGO (1), 2019, AND (1), 2019, ARE (1), ...
-      * Table `country`: foreign key `year`, `country_code` into table `wb_gdp`: values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_density`: values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_total`: values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_urban`: values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_gdp`: values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_density`: values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_total`: values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_urban`: values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1), 2019, WLF (1)
       * Table `country`: foreign key `year`, `country_code` into table `who_community`: values of `country$year`, `country$country_code` not in `who_community$year`, `who_community$country_code`: 2019, ABW (1), 2019, ALB (1), 2019, AND (1), 2019, ARE (1), 2019, ARG (1), ...
 
 ---
@@ -211,10 +221,10 @@
         dm)), problem != ""), problem))
     Output
       values of `country$year`, `country$country_code` not in `gf_procurement$year`, `gf_procurement$country_code`: 2019, ABW (1), 2019, AFG (1), 2019, AGO (1), 2019, AND (1), 2019, ARE (1), ...
-      values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1)
+      values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1), 2019, WLF (1)
       values of `country$year`, `country$country_code` not in `who_community$year`, `who_community$country_code`: 2019, ABW (1), 2019, ALB (1), 2019, AND (1), 2019, ARE (1), 2019, ARG (1), ...
 
 # build_dm() works and returns a time series
@@ -222,122 +232,122 @@
     Code
       dm::glimpse(dm)
     Output
-      dm of 12 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
+      dm of 13 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
       
       --------------------------------------------------------------------------------
       
       Table: `gf_procurement`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 137
       Columns: 3
-      $ country_code      <chr> "AFG", "AFG", "AGO", "AGO", "AGO", "ALB", "ARM", "AR~
-      $ year              <dbl> 2020, 2021, 2020, 2021, 2022, 2019, 2020, 2023, 2021~
-      $ total_numb_device <dbl> 55000, 90800, 30000, 43890, 11000, 2002, 300, 4500, ~
+      $ country_code      <chr> "AFG", "AFG", "AGO", "AGO", "ALB", "ARM", "AZE", "BD~
+      $ year              <dbl> 2020, 2021, 2020, 2021, 2019, 2020, 2021, 2019, 2021~
+      $ total_numb_device <dbl> 55000, 90800, 30000, 43890, 2002, 300, 16500, 9300, ~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_gdp`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ gdp          <dbl> NA, 14583135237, 20143451706, 18904502222, 18418860354, 1~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ gdp          <dbl> 14583135237, 20143451706, 18904502222, 18418860354, 18896~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_density`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ pop_density  <dbl> NA, 61.48055, 59.75228, 57.90825, 56.24823, 54.64854, 53.~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ pop_density  <dbl> 61.48055, 59.75228, 57.90825, 56.24823, 54.64854, 53.1042~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_total`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ pop_total    <dbl> 41128771, 40099462, 38972230, 37769499, 36686784, 3564341~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ pop_total    <dbl> 40099462, 38972230, 37769499, 36686784, 35643418, 3463620~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_urban`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year           <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 2~
-      $ country_code   <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG",~
-      $ pop_urban_perc <dbl> 26.616, 26.314, 26.026, 25.754, 25.495, 25.250, 25.020,~
+      $ year           <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 2~
+      $ country_code   <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB",~
+      $ pop_urban_perc <dbl> 26.314, 26.026, 25.754, 25.495, 25.250, 25.020, 62.969,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_budget`
       Primary key: (`year`, `country_code`)
       
-      Rows: 965
+      Rows: 784
       Columns: 12
-      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "ALB"~
-      $ year            <dbl> 2018, 2019, 2020, 2021, 2022, 2018, 2019, 2020, 2021, ~
-      $ budget_lab      <dbl> 2543262, 2797414, 3200000, 1696418, 515246, NA, NA, NA~
-      $ budget_oth      <dbl> NA, 5344361, 4000000, 3606831, 3529753, NA, NA, NA, NA~
-      $ budget_staff    <dbl> 761828, 915527, 2300000, 570776, 729629, NA, NA, NA, N~
-      $ cf_lab          <dbl> 2473391, 2208668, 3188713, 1696418, 715071, NA, NA, NA~
-      $ cf_staff        <dbl> 741545, 871931, 2248593, 570776, 672737, NA, NA, NA, N~
-      $ cf_tot_domestic <dbl> 533779, 511854, 1171864, NA, 269339, NA, NA, NA, NA, N~
-      $ cf_tot_gf       <dbl> 3178499, 6533095, 6935551, 7638546, 6876137, NA, NA, N~
-      $ cf_tot_grnt     <dbl> 2523675, 3608394, 6871009, 2995053, 1898528, NA, NA, N~
-      $ cf_tot_sources  <dbl> 10698483, 13419792, 17978424, 10633599, 10599950, NA, ~
-      $ cf_tot_usaid    <dbl> 4462530, 2766449, 3000000, NA, 1555946, NA, NA, NA, NA~
+      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "ALB", "ALB"~
+      $ year            <dbl> 2018, 2019, 2020, 2021, 2018, 2019, 2020, 2021, 2018, ~
+      $ budget_lab      <dbl> 2543262, 2797414, 3200000, 1696418, NA, NA, NA, NA, NA~
+      $ budget_oth      <dbl> NA, 5344361, 4000000, 3606831, NA, NA, NA, NA, NA, NA,~
+      $ budget_staff    <dbl> 761828, 915527, 2300000, 570776, NA, NA, NA, NA, NA, N~
+      $ cf_lab          <dbl> 2473391, 2208668, 3188713, 1696418, NA, NA, NA, NA, NA~
+      $ cf_staff        <dbl> 741545, 871931, 2248593, 570776, NA, NA, NA, NA, NA, N~
+      $ cf_tot_domestic <dbl> 533779, 511854, 1171864, NA, NA, NA, NA, NA, NA, NA, N~
+      $ cf_tot_gf       <dbl> 3178499, 6533095, 6935551, 7638546, NA, NA, NA, NA, NA~
+      $ cf_tot_grnt     <dbl> 2523675, 3608394, 6871009, 2995053, NA, NA, NA, NA, NA~
+      $ cf_tot_sources  <dbl> 10698483, 13419792, 17978424, 10633599, NA, NA, NA, NA~
+      $ cf_tot_usaid    <dbl> 4462530, 2766449, 3000000, NA, NA, NA, NA, NA, NA, NA,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_community`
       Primary key: (`year`, `country_code`)
       
-      Rows: 814
+      Rows: 581
       Columns: 9
-      $ country_code           <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG"~
-      $ year                   <dbl> 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020,~
-      $ bmu                    <dbl> NA, 722, 708, 778, 817, 887, 873, 857, 852, 28,~
-      $ bmu_community_impl     <dbl> NA, NA, 539, 778, 817, 887, 719, 857, 718, 28, ~
-      $ bmu_ref_data           <dbl> NA, 661, 539, 778, 817, 887, 719, 857, 718, NA,~
-      $ bmu_rxsupport_data     <dbl> 661, 506, 750, 778, 778, 719, NA, 718, NA, NA, ~
-      $ bmu_rxsupport_data_coh <dbl> NA, 811, 37001, 43046, 46640, 5869, 873, 4981, ~
-      $ notified_ref           <dbl> NA, 15946, 35878, 19710, 47406, 48421, 7248, 46~
-      $ notified_ref_community <dbl> NA, 1088, 1146, 1857, 5214, 7021, 3052, 7529, 5~
+      $ country_code           <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB"~
+      $ year                   <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2016,~
+      $ bmu                    <dbl> 778, 817, 887, 873, 857, 852, 28, 240, 250, 247~
+      $ bmu_community_impl     <dbl> 778, 817, 887, 719, 857, 718, NA, 240, 17, NA, ~
+      $ bmu_ref_data           <dbl> 778, 817, 887, 719, 857, 718, NA, 0, NA, NA, NA~
+      $ bmu_rxsupport_data     <dbl> 778, 778, 719, NA, 718, NA, NA, NA, NA, NA, NA,~
+      $ bmu_rxsupport_data_coh <dbl> 43046, 46640, 5869, 873, 4981, NA, NA, NA, NA, ~
+      $ notified_ref           <dbl> 19710, 47406, 48421, 7248, 46058, 5195, NA, 0, ~
+      $ notified_ref_community <dbl> 1857, 5214, 7021, 3052, 7529, 5195, NA, 0, NA, ~
       
       --------------------------------------------------------------------------------
       
       Table: `who_estimates`
       Primary key: (`year`, `country_code`)
       
-      Rows: 4,223
+      Rows: 1,176
       Columns: 8
-      $ country_code  <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", ~
-      $ year          <dbl> 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 20~
-      $ c_cdr         <dbl> 19, 27, 35, 32, 41, 47, 53, 59, 57, 50, 53, 51, 50, 51, ~
-      $ c_newinc_100k <dbl> 36, 51, 66, 61, 78, 89, 100, 111, 107, 95, 99, 96, 94, 9~
-      $ e_inc_100k    <dbl> 190, 189, 189, 189, 189, 189, 189, 189, 189, 189, 189, 1~
-      $ e_inc_num     <dbl> 37000, 37000, 40000, 43000, 44000, 46000, 48000, 49000, ~
-      $ e_mort_100k   <dbl> 68.00, 63.00, 57.00, 58.00, 52.00, 47.00, 43.00, 39.00, ~
-      $ e_pop_num     <dbl> 19542982, 19688632, 21000256, 22645130, 23553551, 244111~
+      $ country_code  <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", ~
+      $ year          <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, 20~
+      $ c_cdr         <dbl> 64, 69, 70, 74, 62, 66, 87, 87, 87, 87, 54, 56, 80, 80, ~
+      $ c_newinc_100k <dbl> 121.0, 131.0, 132.0, 139.0, 118.0, 125.0, 14.0, 17.0, 15~
+      $ e_inc_100k    <dbl> 189.0, 189.0, 189.0, 189.0, 189.0, 189.0, 17.0, 20.0, 18~
+      $ e_inc_num     <dbl> 65000, 67000, 69000, 71000, 74000, 76000, 480, 580, 500,~
+      $ e_mort_100k   <dbl> 34.00, 30.00, 29.00, 26.00, 34.00, 31.00, 0.37, 0.38, 0.~
+      $ e_pop_num     <dbl> 34636207, 35643418, 36686784, 37769499, 38972230, 400994~
       
       --------------------------------------------------------------------------------
       
       Table: `who_expenditures`
       Primary key: (`year`, `country_code`)
       
-      Rows: 965
+      Rows: 980
       Columns: 9
       $ country_code      <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "AL~
       $ year              <dbl> 2017, 2018, 2019, 2020, 2021, 2017, 2018, 2019, 2020~
@@ -354,41 +364,41 @@
       Table: `who_laboratories`
       Primary key: (`year`, `country_code`)
       
-      Rows: 2,507
+      Rows: 1,176
       Columns: 11
-      $ country_code          <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG",~
-      $ year                  <dbl> 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, ~
-      $ culture               <dbl> NA, NA, NA, NA, NA, NA, 4, 5, 4, 4, 4, 4, 3, NA,~
-      $ lab_cul               <dbl> NA, 1, 3, 2, 3, 3, NA, NA, NA, NA, NA, NA, NA, N~
-      $ lab_sm                <dbl> 596, 600, 600, 603, 667, 720, NA, NA, NA, NA, NA~
-      $ smear                 <dbl> NA, NA, NA, NA, NA, NA, 708, 778, 817, 887, 873,~
-      $ lab_xpert             <dbl> NA, NA, NA, 1, 1, 1, NA, NA, NA, NA, NA, NA, NA,~
-      $ xpert                 <dbl> NA, NA, NA, NA, NA, NA, 1, 6, 20, 42, 47, NA, NA~
-      $ m_wrd                 <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 76, ~
-      $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ country_code          <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB",~
+      $ year                  <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, ~
+      $ culture               <dbl> 5, 4, 4, 4, 4, 3, 1, 1, 1, 1, 1, 1, 29, 30, 28, ~
+      $ lab_cul               <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ lab_sm                <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ smear                 <dbl> 778, 817, 887, 873, 857, 852, 12, 12, 12, 12, 12~
+      $ lab_xpert             <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ xpert                 <dbl> 6, 20, 42, 47, NA, NA, 0, 0, 0, 1, NA, NA, 1, 2,~
+      $ m_wrd                 <dbl> NA, NA, NA, NA, 76, 84, NA, NA, NA, NA, 1, 1, NA~
+      $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, 55909, NA, NA, NA, NA, NA, 1~
+      $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, 18981, NA, NA, NA, NA, NA, 2~
       
       --------------------------------------------------------------------------------
       
       Table: `who_notifications`
       Primary key: (`year`, `country_code`)
       
-      Rows: 8,196
+      Rows: 1,176
       Columns: 8
-      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG"~
-      $ year            <dbl> 1980, 1981, 1982, 1983, 1984, 1985, 1986, 1987, 1988, ~
-      $ conf_rrmdr_tx   <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ conf_xdr_tx     <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ new_clindx      <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ ret_rel_labconf <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ c_newinc        <dbl> 71685, 71554, 41752, 52502, 18784, 10742, 14351, 18091~
-      $ new_labconf     <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
+      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB"~
+      $ year            <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, ~
+      $ conf_rrmdr_tx   <dbl> 153, 198, 317, 396, NA, NA, 1, 0, 4, 2, NA, NA, 31, 40~
+      $ conf_xdr_tx     <dbl> 0, 5, 8, 5, NA, NA, 0, 0, 0, 0, NA, NA, 5, 4, 4, NA, N~
+      $ new_clindx      <dbl> 11506, 13029, 12436, 13698, 10917, 12254, 92, 131, 118~
+      $ ret_rel_labconf <dbl> 1328, 1467, 1477, 763, 435, 501, 7, 15, 10, 14, 13, 5,~
+      $ c_newinc        <dbl> 41954, 46640, 48420, 52438, 45818, 50324, 415, 503, 44~
+      $ new_labconf     <dbl> 18382, 19479, 20485, 24358, 22888, 24715, 200, 195, 19~
       
       --------------------------------------------------------------------------------
       
       Table: `country`
       Primary key: (`year`, `country_code`)
-      11 outgoing foreign key(s):
+      12 outgoing foreign key(s):
         (`year`, `country_code`) -> (`gf_procurement$year`, `gf_procurement$country_co...
         (`year`, `country_code`) -> (`wb_gdp$year`, `wb_gdp$country_code`) no_action
         (`year`, `country_code`) -> (`wb_pop_density$year`, `wb_pop_density$country_co...
@@ -400,12 +410,22 @@
         (`year`, `country_code`) -> (`who_expenditures$year`, `who_expenditures$countr...
         (`year`, `country_code`) -> (`who_laboratories$year`, `who_laboratories$countr...
         (`year`, `country_code`) -> (`who_notifications$year`, `who_notifications$coun...
+        `country_code` -> `hbc$country_code` no_action
       
-      Rows: 1,158
-      Columns: 3
-      $ country_code <chr> "AGO", "AGO", "AGO", "AGO", "AGO", "AGO", "BGD", "BGD", "~
+      Rows: 1,176
+      Columns: 2
+      $ country_code <chr> "ABW", "ABW", "ABW", "ABW", "ABW", "ABW", "AFG", "AFG", "~
       $ year         <int> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, 201~
-      $ is_hbc       <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ~
+      
+      --------------------------------------------------------------------------------
+      
+      Table: `hbc`
+      Primary key: `country_code`
+      
+      Rows: 196
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ is_hbc       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, ~
       
       --------------------------------------------------------------------------------
 
@@ -437,82 +457,82 @@
     Code
       dm::glimpse(dm)
     Output
-      dm of 12 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
+      dm of 13 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
       
       --------------------------------------------------------------------------------
       
       Table: `gf_procurement`
       Primary key: (`year`, `country_code`)
       
-      Rows: 39
+      Rows: 41
       Columns: 3
-      $ country_code      <chr> "ALB", "BDI", "BFA", "BLR", "BLZ", "BTN", "COG", "ER~
+      $ country_code      <chr> "ALB", "BDI", "BFA", "BLR", "BLZ", "BTN", "COG", "CO~
       $ year              <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019~
-      $ total_numb_device <dbl> 2002, 9300, 310000, 3360, 850, 2552, 3450, 17693, 18~
+      $ total_numb_device <dbl> 2002, 9300, 310000, 3360, 850, 2552, 3450, 2, 17693,~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_gdp`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ gdp          <dbl> 1.890450e+10, 1.540183e+10, 1.717603e+11, 3.155149e+09, 6~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ gdp          <dbl> 1.890450e+10, 1.540183e+10, 1.717603e+11, 6.470000e+08, 3~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_density`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ pop_density  <dbl> 57.908252, 104.167555, 17.930316, 162.431915, 25.951382, ~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ pop_density  <dbl> 57.908252, 104.167555, 17.930316, 236.605000, 162.431915,~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_total`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ country_code <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", "~
-      $ pop_total    <dbl> 37769499, 2854191, 42705368, 76343, 32353588, 44938712, 2~
+      $ country_code <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", "~
+      $ pop_total    <dbl> 37769499, 2854191, 42705368, 47321, 76343, 32353588, 4493~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_urban`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 201
       Columns: 3
       $ year           <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2~
-      $ country_code   <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW",~
-      $ pop_urban_perc <dbl> 25.754, 61.229, 73.189, 87.984, 66.177, 91.991, 63.219,~
+      $ country_code   <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM",~
+      $ pop_urban_perc <dbl> 25.754, 61.229, 73.189, 87.147, 87.984, 66.177, 91.991,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_budget`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 12
-      $ country_code    <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW"~
+      $ country_code    <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM"~
       $ year            <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ budget_lab      <dbl> 2797414, NA, NA, NA, 17133500, 263032, 164346, NA, NA,~
-      $ budget_oth      <dbl> 5344361, NA, NA, NA, 4000000, 0, 162174, NA, NA, NA, 1~
-      $ budget_staff    <dbl> 915527, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA, 103~
-      $ cf_lab          <dbl> 2208668, NA, NA, NA, 7216284, 263032, 164346, NA, NA, ~
-      $ cf_staff        <dbl> 871931, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA, 103~
-      $ cf_tot_domestic <dbl> 511854, NA, NA, NA, 13692478, 2510552, 74089, NA, NA, ~
-      $ cf_tot_gf       <dbl> 6533095, NA, NA, NA, 2416285, 0, 1130669, NA, NA, NA, ~
-      $ cf_tot_grnt     <dbl> 3608394, NA, NA, NA, 4000000, 0, 0, NA, NA, NA, NA, NA~
-      $ cf_tot_sources  <dbl> 13419792, NA, NA, NA, 20108763, 2510552, 1204758, NA, ~
-      $ cf_tot_usaid    <dbl> 2766449, NA, NA, NA, 0, 0, 0, NA, NA, NA, NA, NA, NA, ~
+      $ budget_lab      <dbl> 2797414, NA, NA, NA, NA, 17133500, 263032, 164346, NA,~
+      $ budget_oth      <dbl> 5344361, NA, NA, NA, NA, 4000000, 0, 162174, NA, NA, N~
+      $ budget_staff    <dbl> 915527, NA, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA,~
+      $ cf_lab          <dbl> 2208668, NA, NA, NA, NA, 7216284, 263032, 164346, NA, ~
+      $ cf_staff        <dbl> 871931, NA, NA, NA, NA, 1572700, 0, 73866, NA, NA, NA,~
+      $ cf_tot_domestic <dbl> 511854, NA, NA, NA, NA, 13692478, 2510552, 74089, NA, ~
+      $ cf_tot_gf       <dbl> 6533095, NA, NA, NA, NA, 2416285, 0, 1130669, NA, NA, ~
+      $ cf_tot_grnt     <dbl> 3608394, NA, NA, NA, NA, 4000000, 0, 0, NA, NA, NA, NA~
+      $ cf_tot_sources  <dbl> 13419792, NA, NA, NA, NA, 20108763, 2510552, 1204758, ~
+      $ cf_tot_usaid    <dbl> 2766449, NA, NA, NA, NA, 0, 0, 0, NA, NA, NA, NA, NA, ~
       
       --------------------------------------------------------------------------------
       
@@ -536,49 +556,49 @@
       Table: `who_estimates`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 8
-      $ country_code  <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW", ~
+      $ country_code  <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM", ~
       $ year          <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 20~
-      $ c_cdr         <dbl> 74, 87, 81, 87, 65, 87, 84, 87, 87, 87, 79, 87, 87, 80, ~
-      $ c_newinc_100k <dbl> 139.0, 14.0, 49.0, 6.5, 229.0, 26.0, 22.0, 1.9, 5.9, 5.2~
-      $ e_inc_100k    <dbl> 189.0, 16.0, 61.0, 7.5, 351.0, 29.0, 26.0, 2.2, 6.8, 6.0~
-      $ e_inc_num     <dbl> 71000, 470, 26000, 6, 114000, 13000, 740, 2, 1700, 530, ~
-      $ e_mort_100k   <dbl> 26.00, 0.35, 6.70, 0.61, 62.00, 1.80, 1.60, 0.18, 0.24, ~
-      $ e_pop_num     <dbl> 37769499, 2873883, 42705368, 76343, 32353588, 44745520, ~
+      $ c_cdr         <dbl> 74, 87, 81, 100, 87, 65, 87, 84, 87, 87, 87, 79, 87, 87,~
+      $ c_newinc_100k <dbl> 139.0, 14.0, 49.0, 2.1, 6.5, 229.0, 26.0, 22.0, 1.9, 5.9~
+      $ e_inc_100k    <dbl> 189.0, 16.0, 61.0, 2.1, 7.5, 351.0, 29.0, 26.0, 2.2, 6.8~
+      $ e_inc_num     <dbl> 71000, 470, 26000, 1, 6, 114000, 13000, 740, 2, 1700, 53~
+      $ e_mort_100k   <dbl> 26.00, 0.35, 6.70, 0.17, 0.61, 62.00, 1.80, 1.60, 0.18, ~
+      $ e_pop_num     <dbl> 37769499, 2873883, 42705368, 47321, 76343, 32353588, 447~
       
       --------------------------------------------------------------------------------
       
       Table: `who_expenditures`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 9
-      $ country_code      <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "AB~
+      $ country_code      <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "AR~
       $ year              <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019~
-      $ rcvd_lab          <dbl> 2165197, NA, NA, NA, 784599, 0, 171472, NA, NA, NA, ~
-      $ rcvd_staff        <dbl> 1956088, NA, NA, NA, 173805, 0, 85257, NA, NA, NA, 8~
-      $ rcvd_tot_domestic <dbl> 284773, NA, NA, NA, 2856381, 2532872, 3119098, NA, N~
-      $ rcvd_tot_gf       <dbl> 6573762, NA, NA, NA, 2416285, 0, 1474278, NA, NA, NA~
-      $ rcvd_tot_grnt     <dbl> 4826365, NA, NA, NA, 120054, 0, NA, NA, NA, NA, NA, ~
-      $ rcvd_tot_sources  <dbl> 14984900, NA, NA, NA, 5392720, 2532872, 4593376, NA,~
-      $ rcvd_tot_usaid    <dbl> 3300000, NA, NA, NA, 0, 0, NA, NA, NA, NA, NA, NA, N~
+      $ rcvd_lab          <dbl> 2165197, NA, NA, NA, NA, 784599, 0, 171472, NA, NA, ~
+      $ rcvd_staff        <dbl> 1956088, NA, NA, NA, NA, 173805, 0, 85257, NA, NA, N~
+      $ rcvd_tot_domestic <dbl> 284773, NA, NA, NA, NA, 2856381, 2532872, 3119098, N~
+      $ rcvd_tot_gf       <dbl> 6573762, NA, NA, NA, NA, 2416285, 0, 1474278, NA, NA~
+      $ rcvd_tot_grnt     <dbl> 4826365, NA, NA, NA, NA, 120054, 0, NA, NA, NA, NA, ~
+      $ rcvd_tot_sources  <dbl> 14984900, NA, NA, NA, NA, 5392720, 2532872, 4593376,~
+      $ rcvd_tot_usaid    <dbl> 3300000, NA, NA, NA, NA, 0, 0, NA, NA, NA, NA, NA, N~
       
       --------------------------------------------------------------------------------
       
       Table: `who_laboratories`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 11
-      $ country_code          <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM",~
+      $ country_code          <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG",~
       $ year                  <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ culture               <dbl> 4, 1, 29, 7, 0, 148, 1, NA, NA, NA, 7, 1, NA, 5,~
+      $ culture               <dbl> 4, 1, 29, NA, 7, 0, 148, 1, NA, NA, NA, 7, 1, NA~
       $ lab_cul               <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ lab_sm                <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ smear                 <dbl> 873, 12, 240, 7, 167, 729, 25, NA, NA, NA, 55, 1~
+      $ smear                 <dbl> 873, 12, 240, NA, 7, 167, 729, 25, NA, NA, NA, 5~
       $ lab_xpert             <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ xpert                 <dbl> 47, 1, 4, 3, 22, 12, 13, NA, NA, NA, 11, 0, NA, ~
+      $ xpert                 <dbl> 47, 1, 4, NA, 3, 22, 12, 13, NA, NA, NA, 11, 0, ~
       $ m_wrd                 <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
       $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
@@ -588,22 +608,22 @@
       Table: `who_notifications`
       Primary key: (`year`, `country_code`)
       
-      Rows: 195
+      Rows: 203
       Columns: 8
-      $ country_code    <chr> "AFG", "ALB", "DZA", "AND", "AGO", "ARG", "ARM", "ABW"~
+      $ country_code    <chr> "AFG", "ALB", "DZA", "ASM", "AND", "AGO", "ARG", "ARM"~
       $ year            <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, ~
-      $ conf_rrmdr_tx   <dbl> 396, 2, NA, 0, 1523, 222, 65, 0, 29, NA, 815, 1, 2, 12~
-      $ conf_xdr_tx     <dbl> 5, 0, NA, 0, 0, 4, 12, 0, 1, NA, 186, 0, 0, 7, 287, 0,~
-      $ new_clindx      <dbl> 13698, 88, 968, NA, 32278, 2379, 142, 0, 109, 25, 872,~
-      $ ret_rel_labconf <dbl> 763, 14, 230, NA, 2299, 169, 31, NA, 38, 16, 1000, 4, ~
-      $ c_newinc        <dbl> 52438, 412, 20879, 5, 74105, 11446, 621, 2, 1502, 464,~
-      $ new_labconf     <dbl> 24358, 211, 5422, 4, 34887, 7226, 239, 1, 771, 286, 19~
+      $ conf_rrmdr_tx   <dbl> 396, 2, NA, 0, 0, 1523, 222, 65, 0, 29, NA, 815, 1, 2,~
+      $ conf_xdr_tx     <dbl> 5, 0, NA, 0, 0, 0, 4, 12, 0, 1, NA, 186, 0, 0, 7, 287,~
+      $ new_clindx      <dbl> 13698, 88, 968, 0, NA, 32278, 2379, 142, 0, 109, 25, 8~
+      $ ret_rel_labconf <dbl> 763, 14, 230, 0, NA, 2299, 169, 31, NA, 38, 16, 1000, ~
+      $ c_newinc        <dbl> 52438, 412, 20879, 1, 5, 74105, 11446, 621, 2, 1502, 4~
+      $ new_labconf     <dbl> 24358, 211, 5422, 1, 4, 34887, 7226, 239, 1, 771, 286,~
       
       --------------------------------------------------------------------------------
       
       Table: `country`
       Primary key: (`year`, `country_code`)
-      11 outgoing foreign key(s):
+      12 outgoing foreign key(s):
         (`year`, `country_code`) -> (`gf_procurement$year`, `gf_procurement$country_co...
         (`year`, `country_code`) -> (`wb_gdp$year`, `wb_gdp$country_code`) no_action
         (`year`, `country_code`) -> (`wb_pop_density$year`, `wb_pop_density$country_co...
@@ -615,12 +635,22 @@
         (`year`, `country_code`) -> (`who_expenditures$year`, `who_expenditures$countr...
         (`year`, `country_code`) -> (`who_laboratories$year`, `who_laboratories$countr...
         (`year`, `country_code`) -> (`who_notifications$year`, `who_notifications$coun...
+        `country_code` -> `hbc$country_code` no_action
       
-      Rows: 195
-      Columns: 3
-      $ country_code <chr> "AGO", "BGD", "BRA", "CAF", "CHN", "COD", "COG", "ETH", "~
-      $ year         <int> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
-      $ is_hbc       <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ~
+      Rows: 203
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ year         <dbl> 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 2019, 201~
+      
+      --------------------------------------------------------------------------------
+      
+      Table: `hbc`
+      Primary key: `country_code`
+      
+      Rows: 203
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ is_hbc       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, ~
       
       --------------------------------------------------------------------------------
 
@@ -632,10 +662,10 @@
       ! Unsatisfied constraints:
     Output
       * Table `country`: foreign key `year`, `country_code` into table `gf_procurement`: values of `country$year`, `country$country_code` not in `gf_procurement$year`, `gf_procurement$country_code`: 2019, ABW (1), 2019, AFG (1), 2019, AGO (1), 2019, AND (1), 2019, ARE (1), ...
-      * Table `country`: foreign key `year`, `country_code` into table `wb_gdp`: values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_density`: values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_total`: values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1)
-      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_urban`: values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_gdp`: values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_density`: values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_total`: values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1), 2019, WLF (1)
+      * Table `country`: foreign key `year`, `country_code` into table `wb_pop_urban`: values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1), 2019, WLF (1)
       * Table `country`: foreign key `year`, `country_code` into table `who_community`: values of `country$year`, `country$country_code` not in `who_community$year`, `who_community$country_code`: 2019, ABW (1), 2019, ALB (1), 2019, AND (1), 2019, ARE (1), 2019, ARG (1), ...
 
 ---
@@ -645,10 +675,10 @@
         dm)), problem != ""), problem))
     Output
       values of `country$year`, `country$country_code` not in `gf_procurement$year`, `gf_procurement$country_code`: 2019, ABW (1), 2019, AFG (1), 2019, AGO (1), 2019, AND (1), 2019, ARE (1), ...
-      values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1)
-      values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1)
+      values of `country$year`, `country$country_code` not in `wb_gdp$year`, `wb_gdp$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_density$year`, `wb_pop_density$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_total$year`, `wb_pop_total$country_code`: 2019, COK (1), 2019, WLF (1)
+      values of `country$year`, `country$country_code` not in `wb_pop_urban$year`, `wb_pop_urban$country_code`: 2019, COK (1), 2019, WLF (1)
       values of `country$year`, `country$country_code` not in `who_community$year`, `who_community$country_code`: 2019, ABW (1), 2019, ALB (1), 2019, AND (1), 2019, ARE (1), 2019, ARG (1), ...
 
 # build_dm() works and returns a time series with `NULL` args.
@@ -656,122 +686,122 @@
     Code
       dm::glimpse(dm)
     Output
-      dm of 12 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
+      dm of 13 tables: `gf_procurement`, `wb_gdp`, `wb_pop_density`, `wb_pop_total`, `...
       
       --------------------------------------------------------------------------------
       
       Table: `gf_procurement`
       Primary key: (`year`, `country_code`)
       
-      Rows: 194
+      Rows: 137
       Columns: 3
-      $ country_code      <chr> "AFG", "AFG", "AGO", "AGO", "AGO", "ALB", "ARM", "AR~
-      $ year              <dbl> 2020, 2021, 2020, 2021, 2022, 2019, 2020, 2023, 2021~
-      $ total_numb_device <dbl> 55000, 90800, 30000, 43890, 11000, 2002, 300, 4500, ~
+      $ country_code      <chr> "AFG", "AFG", "AGO", "AGO", "ALB", "ARM", "AZE", "BD~
+      $ year              <dbl> 2020, 2021, 2020, 2021, 2019, 2020, 2021, 2019, 2021~
+      $ total_numb_device <dbl> 55000, 90800, 30000, 43890, 2002, 300, 16500, 9300, ~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_gdp`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ gdp          <dbl> NA, 14583135237, 20143451706, 18904502222, 18418860354, 1~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ gdp          <dbl> 14583135237, 20143451706, 18904502222, 18418860354, 18896~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_density`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ pop_density  <dbl> NA, 61.48055, 59.75228, 57.90825, 56.24823, 54.64854, 53.~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ pop_density  <dbl> 61.48055, 59.75228, 57.90825, 56.24823, 54.64854, 53.1042~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_total`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year         <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 202~
-      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "~
-      $ pop_total    <dbl> 41128771, 40099462, 38972230, 37769499, 36686784, 3564341~
+      $ year         <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 201~
+      $ country_code <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "~
+      $ pop_total    <dbl> 40099462, 38972230, 37769499, 36686784, 35643418, 3463620~
       
       --------------------------------------------------------------------------------
       
       Table: `wb_pop_urban`
       Primary key: (`year`, `country_code`)
       
-      Rows: 1,544
+      Rows: 1,176
       Columns: 3
-      $ year           <dbl> 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2022, 2~
-      $ country_code   <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG",~
-      $ pop_urban_perc <dbl> 26.616, 26.314, 26.026, 25.754, 25.495, 25.250, 25.020,~
+      $ year           <dbl> 2021, 2020, 2019, 2018, 2017, 2016, 2021, 2020, 2019, 2~
+      $ country_code   <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB",~
+      $ pop_urban_perc <dbl> 26.314, 26.026, 25.754, 25.495, 25.250, 25.020, 62.969,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_budget`
       Primary key: (`year`, `country_code`)
       
-      Rows: 965
+      Rows: 784
       Columns: 12
-      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "ALB"~
-      $ year            <dbl> 2018, 2019, 2020, 2021, 2022, 2018, 2019, 2020, 2021, ~
-      $ budget_lab      <dbl> 2543262, 2797414, 3200000, 1696418, 515246, NA, NA, NA~
-      $ budget_oth      <dbl> NA, 5344361, 4000000, 3606831, 3529753, NA, NA, NA, NA~
-      $ budget_staff    <dbl> 761828, 915527, 2300000, 570776, 729629, NA, NA, NA, N~
-      $ cf_lab          <dbl> 2473391, 2208668, 3188713, 1696418, 715071, NA, NA, NA~
-      $ cf_staff        <dbl> 741545, 871931, 2248593, 570776, 672737, NA, NA, NA, N~
-      $ cf_tot_domestic <dbl> 533779, 511854, 1171864, NA, 269339, NA, NA, NA, NA, N~
-      $ cf_tot_gf       <dbl> 3178499, 6533095, 6935551, 7638546, 6876137, NA, NA, N~
-      $ cf_tot_grnt     <dbl> 2523675, 3608394, 6871009, 2995053, 1898528, NA, NA, N~
-      $ cf_tot_sources  <dbl> 10698483, 13419792, 17978424, 10633599, 10599950, NA, ~
-      $ cf_tot_usaid    <dbl> 4462530, 2766449, 3000000, NA, 1555946, NA, NA, NA, NA~
+      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "ALB", "ALB"~
+      $ year            <dbl> 2018, 2019, 2020, 2021, 2018, 2019, 2020, 2021, 2018, ~
+      $ budget_lab      <dbl> 2543262, 2797414, 3200000, 1696418, NA, NA, NA, NA, NA~
+      $ budget_oth      <dbl> NA, 5344361, 4000000, 3606831, NA, NA, NA, NA, NA, NA,~
+      $ budget_staff    <dbl> 761828, 915527, 2300000, 570776, NA, NA, NA, NA, NA, N~
+      $ cf_lab          <dbl> 2473391, 2208668, 3188713, 1696418, NA, NA, NA, NA, NA~
+      $ cf_staff        <dbl> 741545, 871931, 2248593, 570776, NA, NA, NA, NA, NA, N~
+      $ cf_tot_domestic <dbl> 533779, 511854, 1171864, NA, NA, NA, NA, NA, NA, NA, N~
+      $ cf_tot_gf       <dbl> 3178499, 6533095, 6935551, 7638546, NA, NA, NA, NA, NA~
+      $ cf_tot_grnt     <dbl> 2523675, 3608394, 6871009, 2995053, NA, NA, NA, NA, NA~
+      $ cf_tot_sources  <dbl> 10698483, 13419792, 17978424, 10633599, NA, NA, NA, NA~
+      $ cf_tot_usaid    <dbl> 4462530, 2766449, 3000000, NA, NA, NA, NA, NA, NA, NA,~
       
       --------------------------------------------------------------------------------
       
       Table: `who_community`
       Primary key: (`year`, `country_code`)
       
-      Rows: 814
+      Rows: 581
       Columns: 9
-      $ country_code           <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG"~
-      $ year                   <dbl> 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020,~
-      $ bmu                    <dbl> NA, 722, 708, 778, 817, 887, 873, 857, 852, 28,~
-      $ bmu_community_impl     <dbl> NA, NA, 539, 778, 817, 887, 719, 857, 718, 28, ~
-      $ bmu_ref_data           <dbl> NA, 661, 539, 778, 817, 887, 719, 857, 718, NA,~
-      $ bmu_rxsupport_data     <dbl> 661, 506, 750, 778, 778, 719, NA, 718, NA, NA, ~
-      $ bmu_rxsupport_data_coh <dbl> NA, 811, 37001, 43046, 46640, 5869, 873, 4981, ~
-      $ notified_ref           <dbl> NA, 15946, 35878, 19710, 47406, 48421, 7248, 46~
-      $ notified_ref_community <dbl> NA, 1088, 1146, 1857, 5214, 7021, 3052, 7529, 5~
+      $ country_code           <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB"~
+      $ year                   <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2016,~
+      $ bmu                    <dbl> 778, 817, 887, 873, 857, 852, 28, 240, 250, 247~
+      $ bmu_community_impl     <dbl> 778, 817, 887, 719, 857, 718, NA, 240, 17, NA, ~
+      $ bmu_ref_data           <dbl> 778, 817, 887, 719, 857, 718, NA, 0, NA, NA, NA~
+      $ bmu_rxsupport_data     <dbl> 778, 778, 719, NA, 718, NA, NA, NA, NA, NA, NA,~
+      $ bmu_rxsupport_data_coh <dbl> 43046, 46640, 5869, 873, 4981, NA, NA, NA, NA, ~
+      $ notified_ref           <dbl> 19710, 47406, 48421, 7248, 46058, 5195, NA, 0, ~
+      $ notified_ref_community <dbl> 1857, 5214, 7021, 3052, 7529, 5195, NA, 0, NA, ~
       
       --------------------------------------------------------------------------------
       
       Table: `who_estimates`
       Primary key: (`year`, `country_code`)
       
-      Rows: 4,223
+      Rows: 1,176
       Columns: 8
-      $ country_code  <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", ~
-      $ year          <dbl> 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 20~
-      $ c_cdr         <dbl> 19, 27, 35, 32, 41, 47, 53, 59, 57, 50, 53, 51, 50, 51, ~
-      $ c_newinc_100k <dbl> 36, 51, 66, 61, 78, 89, 100, 111, 107, 95, 99, 96, 94, 9~
-      $ e_inc_100k    <dbl> 190, 189, 189, 189, 189, 189, 189, 189, 189, 189, 189, 1~
-      $ e_inc_num     <dbl> 37000, 37000, 40000, 43000, 44000, 46000, 48000, 49000, ~
-      $ e_mort_100k   <dbl> 68.00, 63.00, 57.00, 58.00, 52.00, 47.00, 43.00, 39.00, ~
-      $ e_pop_num     <dbl> 19542982, 19688632, 21000256, 22645130, 23553551, 244111~
+      $ country_code  <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", ~
+      $ year          <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, 20~
+      $ c_cdr         <dbl> 64, 69, 70, 74, 62, 66, 87, 87, 87, 87, 54, 56, 80, 80, ~
+      $ c_newinc_100k <dbl> 121.0, 131.0, 132.0, 139.0, 118.0, 125.0, 14.0, 17.0, 15~
+      $ e_inc_100k    <dbl> 189.0, 189.0, 189.0, 189.0, 189.0, 189.0, 17.0, 20.0, 18~
+      $ e_inc_num     <dbl> 65000, 67000, 69000, 71000, 74000, 76000, 480, 580, 500,~
+      $ e_mort_100k   <dbl> 34.00, 30.00, 29.00, 26.00, 34.00, 31.00, 0.37, 0.38, 0.~
+      $ e_pop_num     <dbl> 34636207, 35643418, 36686784, 37769499, 38972230, 400994~
       
       --------------------------------------------------------------------------------
       
       Table: `who_expenditures`
       Primary key: (`year`, `country_code`)
       
-      Rows: 965
+      Rows: 980
       Columns: 9
       $ country_code      <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB", "AL~
       $ year              <dbl> 2017, 2018, 2019, 2020, 2021, 2017, 2018, 2019, 2020~
@@ -788,41 +818,41 @@
       Table: `who_laboratories`
       Primary key: (`year`, `country_code`)
       
-      Rows: 2,507
+      Rows: 1,176
       Columns: 11
-      $ country_code          <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG",~
-      $ year                  <dbl> 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, ~
-      $ culture               <dbl> NA, NA, NA, NA, NA, NA, 4, 5, 4, 4, 4, 4, 3, NA,~
-      $ lab_cul               <dbl> NA, 1, 3, 2, 3, 3, NA, NA, NA, NA, NA, NA, NA, N~
-      $ lab_sm                <dbl> 596, 600, 600, 603, 667, 720, NA, NA, NA, NA, NA~
-      $ smear                 <dbl> NA, NA, NA, NA, NA, NA, 708, 778, 817, 887, 873,~
-      $ lab_xpert             <dbl> NA, NA, NA, 1, 1, 1, NA, NA, NA, NA, NA, NA, NA,~
-      $ xpert                 <dbl> NA, NA, NA, NA, NA, NA, 1, 6, 20, 42, 47, NA, NA~
-      $ m_wrd                 <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, 76, ~
-      $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
-      $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ country_code          <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB",~
+      $ year                  <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, ~
+      $ culture               <dbl> 5, 4, 4, 4, 4, 3, 1, 1, 1, 1, 1, 1, 29, 30, 28, ~
+      $ lab_cul               <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ lab_sm                <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ smear                 <dbl> 778, 817, 887, 873, 857, 852, 12, 12, 12, 12, 12~
+      $ lab_xpert             <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, ~
+      $ xpert                 <dbl> 6, 20, 42, 47, NA, NA, 0, 0, 0, 1, NA, NA, 1, 2,~
+      $ m_wrd                 <dbl> NA, NA, NA, NA, 76, 84, NA, NA, NA, NA, 1, 1, NA~
+      $ m_wrd_tests_performed <dbl> NA, NA, NA, NA, NA, 55909, NA, NA, NA, NA, NA, 1~
+      $ m_wrd_tests_positive  <dbl> NA, NA, NA, NA, NA, 18981, NA, NA, NA, NA, NA, 2~
       
       --------------------------------------------------------------------------------
       
       Table: `who_notifications`
       Primary key: (`year`, `country_code`)
       
-      Rows: 8,196
+      Rows: 1,176
       Columns: 8
-      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "AFG"~
-      $ year            <dbl> 1980, 1981, 1982, 1983, 1984, 1985, 1986, 1987, 1988, ~
-      $ conf_rrmdr_tx   <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ conf_xdr_tx     <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ new_clindx      <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ ret_rel_labconf <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
-      $ c_newinc        <dbl> 71685, 71554, 41752, 52502, 18784, 10742, 14351, 18091~
-      $ new_labconf     <dbl> NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA~
+      $ country_code    <chr> "AFG", "AFG", "AFG", "AFG", "AFG", "AFG", "ALB", "ALB"~
+      $ year            <dbl> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, ~
+      $ conf_rrmdr_tx   <dbl> 153, 198, 317, 396, NA, NA, 1, 0, 4, 2, NA, NA, 31, 40~
+      $ conf_xdr_tx     <dbl> 0, 5, 8, 5, NA, NA, 0, 0, 0, 0, NA, NA, 5, 4, 4, NA, N~
+      $ new_clindx      <dbl> 11506, 13029, 12436, 13698, 10917, 12254, 92, 131, 118~
+      $ ret_rel_labconf <dbl> 1328, 1467, 1477, 763, 435, 501, 7, 15, 10, 14, 13, 5,~
+      $ c_newinc        <dbl> 41954, 46640, 48420, 52438, 45818, 50324, 415, 503, 44~
+      $ new_labconf     <dbl> 18382, 19479, 20485, 24358, 22888, 24715, 200, 195, 19~
       
       --------------------------------------------------------------------------------
       
       Table: `country`
       Primary key: (`year`, `country_code`)
-      11 outgoing foreign key(s):
+      12 outgoing foreign key(s):
         (`year`, `country_code`) -> (`gf_procurement$year`, `gf_procurement$country_co...
         (`year`, `country_code`) -> (`wb_gdp$year`, `wb_gdp$country_code`) no_action
         (`year`, `country_code`) -> (`wb_pop_density$year`, `wb_pop_density$country_co...
@@ -834,12 +864,22 @@
         (`year`, `country_code`) -> (`who_expenditures$year`, `who_expenditures$countr...
         (`year`, `country_code`) -> (`who_laboratories$year`, `who_laboratories$countr...
         (`year`, `country_code`) -> (`who_notifications$year`, `who_notifications$coun...
+        `country_code` -> `hbc$country_code` no_action
       
-      Rows: 1,158
-      Columns: 3
-      $ country_code <chr> "AGO", "AGO", "AGO", "AGO", "AGO", "AGO", "BGD", "BGD", "~
+      Rows: 1,176
+      Columns: 2
+      $ country_code <chr> "ABW", "ABW", "ABW", "ABW", "ABW", "ABW", "AFG", "AFG", "~
       $ year         <int> 2016, 2017, 2018, 2019, 2020, 2021, 2016, 2017, 2018, 201~
-      $ is_hbc       <dbl> 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ~
+      
+      --------------------------------------------------------------------------------
+      
+      Table: `hbc`
+      Primary key: `country_code`
+      
+      Rows: 196
+      Columns: 2
+      $ country_code <chr> "ABW", "AFG", "AGO", "ALB", "AND", "ARE", "ARG", "ARM", "~
+      $ is_hbc       <dbl> 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, ~
       
       --------------------------------------------------------------------------------
 

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -106,13 +106,30 @@ test_that("get_core() works", {
   skip_on_ci()
   skip_if(Sys.getenv("DXGAP_DATADIR") == "")
   data_list <- build_lst("tb")
-  expect_type(
-    get_core(
-      data_list,
-      estimated = "who_estimates.e_inc_num",
-      notified = "who_notifications.c_newinc",
-      year = NULL
-    ),
-    "list"
+
+  core_lst_hbc_falls_in_between_two_periods <- get_core(
+    data_list,
+    estimated = "who_estimates.e_inc_num",
+    notified = "who_notifications.c_newinc",
+    year = NULL
   )
+  expect_type(core_lst_hbc_falls_in_between_two_periods, "list")
+  core_hbc_df <-
+    core_lst_hbc_falls_in_between_two_periods$hbc |>
+    dplyr::filter(is_hbc == 1)
+  expect_equal(nrow(core_hbc_df), 27)
+
+  core_lst_hbc_falls_in_one_period <- get_core(
+    data_list,
+    estimated = "who_estimates.e_inc_num",
+    notified = "who_notifications.c_newinc",
+    year = 2014:2017
+  )
+  expect_type(core_lst_hbc_falls_in_one_period, "list")
+
+  core_hbc_df <-
+    core_lst_hbc_falls_in_one_period$hbc |>
+    dplyr::filter(is_hbc == 1)
+  expect_equal(nrow(core_hbc_df), 30)
+
 })

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -61,6 +61,24 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
     )
   out <- get_cc_var_always_given_acrs_yrs(df7, var, year_range = 2018)
   expect_equal(out$country_code, c("FRA", "ITA", "CHE"))
+
+  df8 <-
+    tibble::tibble(
+      country_code = rep(c("FRA", "ITA", "CHE"), 4),
+      year = c(rep(2016, 3), rep(2017, 3), rep(2018, 3), rep(2019, 3)),
+      var = c(1, 1, 1, 1, NA, 1, 1, 1, 1, 1, 1, 1)
+    )
+  out <- get_cc_var_always_given_acrs_yrs(df8, var, year_range = 2018:2019)
+  expect_equal(out$country_code, c("FRA", "ITA", "CHE"))
+
+  df9 <-
+    tibble::tibble(
+      country_code = rep(c("FRA", "ITA", "CHE"), 4),
+      year = c(rep(2016, 3), rep(2017, 3), rep(2018, 3), rep(2019, 3)),
+      var = c(1, 1, 1, 1, NA, 1, 1, 1, 1, 1, 1, 1)
+    )
+  out <- get_cc_var_always_given_acrs_yrs(df8, var, year_range = 2017:2019)
+  expect_equal(out$country_code, c("FRA", "CHE"))
 })
 
 test_that("get_cc_var_always_given_acrs_yrs() works", {

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -111,7 +111,7 @@ test_that("get_core() works", {
     data_list,
     estimated = "who_estimates.e_inc_num",
     notified = "who_notifications.c_newinc",
-    year = NULL
+    year = 2016:2021
   )
   expect_type(core_lst_hbc_falls_in_between_two_periods, "list")
   core_hbc_df <-

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -89,10 +89,10 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
   core_df <-
     who_notifications |>
     get_cc_var_always_given_acrs_yrs(c_newinc, year_range = extract_supported_year("tb"))
-  start_year <- extract_start_year("tb")
+  year_range <- extract_supported_year("tb")
   numb_na <-
     who_notifications |>
-    dplyr::filter(year >= start_year) |>
+    dplyr::filter(dplyr::between(year, min(year_range), max(year_range))) |>
     dplyr::semi_join(core_df, dplyr::join_by(country_code)) |>
     dplyr::filter(is.na(c_newinc)) |>
     dplyr::count() |>

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -5,7 +5,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = rep(1, 3 * 3)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df1, var, 2016)
+  out <- get_cc_var_always_given_acrs_yrs(df1, var, year_range = 2016:2018)
   expect_equal(out$country_code, c("FRA", "ITA", "CHE"))
 
   df2 <-
@@ -14,7 +14,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(NA, 1, 1, 1, 1, 1, 1, 1, 1)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df2, var, 2016)
+  out <- get_cc_var_always_given_acrs_yrs(df2, var, year_range = 2016:2018)
   expect_equal(out$country_code, c("ITA", "CHE"))
 
   df3 <-
@@ -23,7 +23,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(NA, 1, 1, 1, NA, 1, 1, 1, NA)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df3, var, 2016)
+  out <- get_cc_var_always_given_acrs_yrs(df3, var, year_range = 2016:2018)
   expect_equal(out$country_code, character(0))
 
   df4 <-
@@ -32,7 +32,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(NA, NA, NA, 1, 1, 1, 1, 1, 1)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df4, var, 2016)
+  out <- get_cc_var_always_given_acrs_yrs(df4, var, year_range = 2016:2018)
   expect_equal(out$country_code, character(0))
 
   df5 <-
@@ -41,7 +41,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(NA, NA, NA, 1, 1, 1, 1, 1, 1)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df5, var, 2017)
+  out <- get_cc_var_always_given_acrs_yrs(df5, var, year_range = 2017:2018)
   expect_equal(out$country_code, c("FRA", "ITA", "CHE"))
 
   df6 <-
@@ -50,7 +50,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(1, 1, 1, 1, NA, 1, 1, 1, 1)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df6, var, 2016)
+  out <- get_cc_var_always_given_acrs_yrs(df6, var, year_range = 2016:2018)
   expect_equal(out$country_code, c("FRA", "CHE"))
 
   df7 <-
@@ -59,7 +59,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
       year = c(2016, 2016, 2016, 2017, 2017, 2017, 2018, 2018, 2018),
       var = c(1, 1, 1, 1, NA, 1, 1, 1, 1)
     )
-  out <- get_cc_var_always_given_acrs_yrs(df7, var, 2018)
+  out <- get_cc_var_always_given_acrs_yrs(df7, var, year_range = 2018)
   expect_equal(out$country_code, c("FRA", "ITA", "CHE"))
 })
 

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -86,10 +86,12 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
   skip_if(Sys.getenv("DXGAP_DATADIR") == "")
   data_list <- build_lst("tb")
   who_notifications <- data_list$who_notifications
+  year_range <- extract_supported_year("tb")
+
   core_df <-
     who_notifications |>
-    get_cc_var_always_given_acrs_yrs(c_newinc, year_range = extract_supported_year("tb"))
-  year_range <- extract_supported_year("tb")
+    get_cc_var_always_given_acrs_yrs(c_newinc, year_range = year_range)
+
   numb_na <-
     who_notifications |>
     dplyr::filter(dplyr::between(year, min(year_range), max(year_range))) |>

--- a/tests/testthat/test-core.R
+++ b/tests/testthat/test-core.R
@@ -70,7 +70,7 @@ test_that("get_cc_var_always_given_acrs_yrs() works", {
   who_notifications <- data_list$who_notifications
   core_df <-
     who_notifications |>
-    get_cc_var_always_given_acrs_yrs(c_newinc, start_year = extract_start_year("tb"))
+    get_cc_var_always_given_acrs_yrs(c_newinc, year_range = extract_supported_year("tb"))
   start_year <- extract_start_year("tb")
   numb_na <-
     who_notifications |>


### PR DESCRIPTION
- Move logic of binding high-burden countries with non-hbc countries from `build_dm()` to `get_core()`.
- The information on whether a country is high-burden now lives in a stand-alone table linked to the parent country table (red table).
- In case further diseases are added, it should now be more accessible to build a data model without the hbc table if we don't get that information for the new disease.
- Additional tests.
- Revise how the filter on the year range is performed and make sure `get_core()` falls back on the year range that is supported for a given disease.

![dm](https://github.com/finddx/find.dxgap/assets/43607279/779e99c7-1459-4c6c-a069-f556d41c8de9)
